### PR TITLE
Add NormalizedCacheFactory.close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next version (unreleased)
 
-PUT_CHANGELOG_HERE
+- Add `NormalizedCacheFactory.close()` (#66)
 
 # Version 0.0.4
 _2024-11-07_

--- a/normalized-cache-incubating/api/normalized-cache-incubating.api
+++ b/normalized-cache-incubating/api/normalized-cache-incubating.api
@@ -389,7 +389,7 @@ public final class com/apollographql/cache/normalized/api/NormalizedCache$Compan
 	public final fun prettifyDump (Ljava/util/Map;)Ljava/lang/String;
 }
 
-public abstract class com/apollographql/cache/normalized/api/NormalizedCacheFactory {
+public abstract class com/apollographql/cache/normalized/api/NormalizedCacheFactory : java/io/Closeable {
 	public fun <init> ()V
 	public abstract fun create ()Lcom/apollographql/cache/normalized/api/NormalizedCache;
 }
@@ -523,6 +523,7 @@ public final class com/apollographql/cache/normalized/memory/MemoryCacheFactory 
 	public fun <init> (IJ)V
 	public synthetic fun <init> (IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun chain (Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;)Lcom/apollographql/cache/normalized/memory/MemoryCacheFactory;
+	public fun close ()V
 	public synthetic fun create ()Lcom/apollographql/cache/normalized/api/NormalizedCache;
 	public fun create ()Lcom/apollographql/cache/normalized/memory/MemoryCache;
 }

--- a/normalized-cache-incubating/api/normalized-cache-incubating.klib.api
+++ b/normalized-cache-incubating/api/normalized-cache-incubating.klib.api
@@ -12,7 +12,7 @@ abstract class com.apollographql.cache.normalized.api/CacheKeyResolver : com.apo
     final fun resolveField(com.apollographql.cache.normalized.api/ResolverContext): kotlin/Any? // com.apollographql.cache.normalized.api/CacheKeyResolver.resolveField|resolveField(com.apollographql.cache.normalized.api.ResolverContext){}[0]
     open fun listOfCacheKeysForField(com.apollographql.cache.normalized.api/ResolverContext): kotlin.collections/List<com.apollographql.cache.normalized.api/CacheKey?>? // com.apollographql.cache.normalized.api/CacheKeyResolver.listOfCacheKeysForField|listOfCacheKeysForField(com.apollographql.cache.normalized.api.ResolverContext){}[0]
 }
-abstract class com.apollographql.cache.normalized.api/NormalizedCacheFactory { // com.apollographql.cache.normalized.api/NormalizedCacheFactory|null[0]
+abstract class com.apollographql.cache.normalized.api/NormalizedCacheFactory : okio/Closeable { // com.apollographql.cache.normalized.api/NormalizedCacheFactory|null[0]
     abstract fun create(): com.apollographql.cache.normalized.api/NormalizedCache // com.apollographql.cache.normalized.api/NormalizedCacheFactory.create|create(){}[0]
     constructor <init>() // com.apollographql.cache.normalized.api/NormalizedCacheFactory.<init>|<init>(){}[0]
 }
@@ -275,6 +275,7 @@ final class com.apollographql.cache.normalized.memory/MemoryCache : com.apollogr
 final class com.apollographql.cache.normalized.memory/MemoryCacheFactory : com.apollographql.cache.normalized.api/NormalizedCacheFactory { // com.apollographql.cache.normalized.memory/MemoryCacheFactory|null[0]
     constructor <init>(kotlin/Int = ..., kotlin/Long = ...) // com.apollographql.cache.normalized.memory/MemoryCacheFactory.<init>|<init>(kotlin.Int;kotlin.Long){}[0]
     final fun chain(com.apollographql.cache.normalized.api/NormalizedCacheFactory): com.apollographql.cache.normalized.memory/MemoryCacheFactory // com.apollographql.cache.normalized.memory/MemoryCacheFactory.chain|chain(com.apollographql.cache.normalized.api.NormalizedCacheFactory){}[0]
+    final fun close() // com.apollographql.cache.normalized.memory/MemoryCacheFactory.close|close(){}[0]
     final fun create(): com.apollographql.cache.normalized.memory/MemoryCache // com.apollographql.cache.normalized.memory/MemoryCacheFactory.create|create(){}[0]
 }
 final class com.apollographql.cache.normalized/CacheInfo : com.apollographql.apollo.api/ExecutionContext.Element { // com.apollographql.cache.normalized/CacheInfo|null[0]

--- a/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/api/NormalizedCacheFactory.kt
+++ b/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/api/NormalizedCacheFactory.kt
@@ -1,10 +1,12 @@
 package com.apollographql.cache.normalized.api
 
+import okio.Closeable
+
 /**
  * A Factory used to construct an instance of a [NormalizedCache] configured with the custom scalar adapters set in
  * ApolloClient.Builder#addCustomScalarAdapter(ScalarType, CustomScalarAdapter).
  */
-abstract class NormalizedCacheFactory {
+abstract class NormalizedCacheFactory : Closeable {
 
   /**
    * ApolloClient.Builder#addCustomScalarAdapter(ScalarType, CustomScalarAdapter).

--- a/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
+++ b/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
@@ -176,4 +176,8 @@ class MemoryCacheFactory @JvmOverloads constructor(
         expireAfterMillis = expireAfterMillis,
     )
   }
+
+  override fun close() {
+    nextCacheFactory?.close()
+  }
 }

--- a/normalized-cache-sqlite-incubating/api/android/normalized-cache-sqlite-incubating.api
+++ b/normalized-cache-sqlite-incubating/api/android/normalized-cache-sqlite-incubating.api
@@ -20,6 +20,10 @@ public final class com/apollographql/cache/normalized/sql/SqlNormalizedCache : c
 	public fun remove (Ljava/lang/String;)I
 }
 
+public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactoryKt {
+	public static final fun SqlNormalizedCacheFactory (Lapp/cash/sqldelight/db/SqlDriver;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
+}
+
 public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory_androidKt {
 	public static final fun SqlNormalizedCacheFactory (Landroid/content/Context;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static final fun SqlNormalizedCacheFactory (Landroid/content/Context;Ljava/lang/String;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
@@ -27,7 +31,6 @@ public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFact
 	public static final fun SqlNormalizedCacheFactory (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static final fun SqlNormalizedCacheFactory (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;Z)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static final fun SqlNormalizedCacheFactory (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;ZLjava/lang/Long;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
-	public static final fun SqlNormalizedCacheFactory (Lapp/cash/sqldelight/db/SqlDriver;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static final fun SqlNormalizedCacheFactory (Ljava/lang/String;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static synthetic fun SqlNormalizedCacheFactory$default (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;ZLjava/lang/Long;ILjava/lang/Object;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static synthetic fun SqlNormalizedCacheFactory$default (Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;

--- a/normalized-cache-sqlite-incubating/api/jvm/normalized-cache-sqlite-incubating.api
+++ b/normalized-cache-sqlite-incubating/api/jvm/normalized-cache-sqlite-incubating.api
@@ -9,8 +9,11 @@ public final class com/apollographql/cache/normalized/sql/SqlNormalizedCache : c
 	public fun remove (Ljava/lang/String;)I
 }
 
-public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory_jvmKt {
+public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactoryKt {
 	public static final fun SqlNormalizedCacheFactory (Lapp/cash/sqldelight/db/SqlDriver;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
+}
+
+public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory_jvmKt {
 	public static final fun SqlNormalizedCacheFactory (Ljava/lang/String;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static final fun SqlNormalizedCacheFactory (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static final fun SqlNormalizedCacheFactory (Ljava/lang/String;Ljava/util/Properties;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
@@ -19,6 +22,7 @@ public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFact
 }
 
 public final class com/apollographql/cache/normalized/sql/TrimmableNormalizedCacheFactory : com/apollographql/cache/normalized/api/NormalizedCacheFactory {
+	public fun close ()V
 	public fun create ()Lcom/apollographql/cache/normalized/api/NormalizedCache;
 }
 

--- a/normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.android.kt
+++ b/normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.android.kt
@@ -6,20 +6,11 @@ import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.sql.internal.createDriver
-import com.apollographql.cache.normalized.sql.internal.createRecordDatabase
 import com.apollographql.cache.normalized.sql.internal.getSchema
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
-import app.cash.sqldelight.db.SqlDriver
-import com.apollographql.cache.normalized.api.NormalizedCache
-
-actual fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory = object : NormalizedCacheFactory() {
-  override fun create(): NormalizedCache {
-    return SqlNormalizedCache(createRecordDatabase(driver))
-  }
-}
 
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory =
-  SqlNormalizedCacheFactory(createDriver(name, null, getSchema()))
+  SqlNormalizedCacheFactory(createDriver(name, null, getSchema()), manageDriver = true)
 
 /**
  * @param [name] Name of the database file, or null for an in-memory database (as per Android framework implementation).
@@ -52,4 +43,5 @@ fun SqlNormalizedCacheFactory(
         useNoBackupDirectory = useNoBackupDirectory,
         windowSizeBytes = windowSizeBytes,
     ),
+    manageDriver = true,
 )

--- a/normalized-cache-sqlite-incubating/src/appleMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.apple.kt
+++ b/normalized-cache-sqlite-incubating/src/appleMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.apple.kt
@@ -1,17 +1,8 @@
 package com.apollographql.cache.normalized.sql
 
-import app.cash.sqldelight.db.SqlDriver
-import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.sql.internal.createDriver
-import com.apollographql.cache.normalized.sql.internal.createRecordDatabase
 import com.apollographql.cache.normalized.sql.internal.getSchema
-
-actual fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory = object : NormalizedCacheFactory() {
-  override fun create(): NormalizedCache {
-    return SqlNormalizedCache(createRecordDatabase(driver))
-  }
-}
 
 /**
  * @param name the name of the database or null for an in-memory database
@@ -22,6 +13,6 @@ actual fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory 
 fun SqlNormalizedCacheFactory(
     name: String?,
     baseDir: String?,
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(createDriver(name, baseDir, getSchema()))
+): NormalizedCacheFactory = SqlNormalizedCacheFactory(createDriver(name, baseDir, getSchema()), manageDriver = true)
 
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory = SqlNormalizedCacheFactory(name, null)

--- a/normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -1,7 +1,9 @@
 package com.apollographql.cache.normalized.sql
 
 import app.cash.sqldelight.db.SqlDriver
+import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.sql.internal.createRecordDatabase
 
 /**
  * Creates a new [NormalizedCacheFactory] that uses a persistent cache based on Sqlite
@@ -15,4 +17,15 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
  */
 expect fun SqlNormalizedCacheFactory(name: String? = "apollo.db"): NormalizedCacheFactory
 
-expect fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory
+fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory = SqlNormalizedCacheFactory(driver, false)
+
+internal fun SqlNormalizedCacheFactory(driver: SqlDriver, manageDriver: Boolean): NormalizedCacheFactory =
+  object : NormalizedCacheFactory() {
+    override fun create(): NormalizedCache {
+      return SqlNormalizedCache(createRecordDatabase(driver))
+    }
+
+    override fun close() {
+      if (manageDriver) driver.close()
+    }
+  }

--- a/normalized-cache-sqlite-incubating/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jvm.kt
+++ b/normalized-cache-sqlite-incubating/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jvm.kt
@@ -1,19 +1,10 @@
 package com.apollographql.cache.normalized.sql
 
-import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
-import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.sql.internal.createDriver
-import com.apollographql.cache.normalized.sql.internal.createRecordDatabase
 import com.apollographql.cache.normalized.sql.internal.getSchema
 import java.util.Properties
-
-actual fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory = object : NormalizedCacheFactory() {
-  override fun create(): NormalizedCache {
-    return SqlNormalizedCache(createRecordDatabase(driver))
-  }
-}
 
 /**
  * @param url Database connection URL in the form of `jdbc:sqlite:path` where `path` is either blank
@@ -23,7 +14,7 @@ actual fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory 
 fun SqlNormalizedCacheFactory(
     url: String,
     properties: Properties = Properties(),
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(JdbcSqliteDriver(url, properties))
+): NormalizedCacheFactory = SqlNormalizedCacheFactory(JdbcSqliteDriver(url, properties), manageDriver = true)
 
 /**
  * @param name the name of the database or null for an in-memory database
@@ -34,6 +25,6 @@ fun SqlNormalizedCacheFactory(
 fun SqlNormalizedCacheFactory(
     name: String?,
     baseDir: String?,
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(createDriver(name, baseDir, getSchema()))
+): NormalizedCacheFactory = SqlNormalizedCacheFactory(createDriver(name, baseDir, getSchema()), manageDriver = true)
 
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory = SqlNormalizedCacheFactory(name, null)

--- a/normalized-cache-sqlite-incubating/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/TrimmableNormalizedCacheFactory.kt
+++ b/normalized-cache-sqlite-incubating/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/TrimmableNormalizedCacheFactory.kt
@@ -43,6 +43,10 @@ class TrimmableNormalizedCacheFactory internal constructor(
 
     return SqlNormalizedCache(Blob2RecordDatabase(queries))
   }
+
+  override fun close() {
+    driver.close()
+  }
 }
 
 

--- a/tests/normalized-cache/src/commonTest/kotlin/NormalizedCacheThreadingTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/NormalizedCacheThreadingTest.kt
@@ -30,6 +30,8 @@ class NormalizedCacheThreadingTest {
             cacheCreateThreadName = currentThreadId()
             return MemoryCacheFactory().create()
           }
+
+          override fun close() {}
         }).build()
     assertNull(cacheCreateThreadName)
 

--- a/tests/normalized-cache/src/commonTest/kotlin/ThreadTests.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/ThreadTests.kt
@@ -87,6 +87,7 @@ class ThreadTests {
       return MyNormalizedCache(mainThreadId)
     }
 
+    override fun close() {}
   }
 
   @Test


### PR DESCRIPTION
Related to #66

`SqlNormalizedCacheFactory.close()` will call `close()` on the `SqlDriver` it creates - if you pass your own driver, it won't close it.