### PR TITLE
Add a test of using partial results with @catch(to: RESULT)

### DIFF
--- a/tests/partial-results/src/commonMain/graphql/extra.graphqls
+++ b/tests/partial-results/src/commonMain/graphql/extra.graphqls
@@ -26,3 +26,5 @@ extend type EmployeeInfo @semanticNonNullField(name: "salary")
 @semanticNonNullField(name: "department")
 
 extend type EmployeeInfo @cacheControlField(name: "salary", maxAge: 0)
+
+extend type DepartmentInfo @cacheControlField(name: "name", maxAge: 0)

--- a/tests/partial-results/src/commonMain/graphql/operation.graphql
+++ b/tests/partial-results/src/commonMain/graphql/operation.graphql
@@ -129,3 +129,14 @@ query MeWithEmployeeInfoQuery {
     }
   }
 }
+
+query MeWithDepartmentInfoQuery {
+  me {
+    firstName
+    lastName
+    departmentInfo {
+      id
+      name @catch(to: RESULT)
+    }
+  }
+}

--- a/tests/partial-results/src/commonMain/graphql/schema.graphqls
+++ b/tests/partial-results/src/commonMain/graphql/schema.graphqls
@@ -19,6 +19,7 @@ type User {
   category: Category!
   moreInfo: Json!
   employeeInfo: EmployeeInfo
+  departmentInfo: DepartmentInfo!
 }
 
 type Project {
@@ -33,6 +34,11 @@ type EmployeeInfo {
   id: ID!
   salary: Int
   department: String
+}
+
+type DepartmentInfo {
+  id: ID!
+  name: String
 }
 
 scalar Category


### PR DESCRIPTION
Shows that partial results from the cache don't necessarily hide non-nullable fields, thanks to error colocation.