### PR TITLE
Make SQL cache more robust

### DIFF
--- a/normalized-cache/api/normalized-cache.api
+++ b/normalized-cache/api/normalized-cache.api
@@ -500,14 +500,15 @@ public abstract interface class com/apollographql/cache/normalized/api/Normalize
 	public abstract fun clearAll ()V
 	public abstract fun merge (Lcom/apollographql/cache/normalized/api/Record;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lcom/apollographql/cache/normalized/api/RecordMerger;)Ljava/util/Set;
 	public abstract fun merge (Ljava/util/Collection;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lcom/apollographql/cache/normalized/api/RecordMerger;)Ljava/util/Set;
-	public static fun prettifyDump (Ljava/util/Map;)Ljava/lang/String;
+	public static fun prettifyDump (Ljava/util/Map;Z)Ljava/lang/String;
 	public abstract fun remove (Ljava/util/Collection;Z)I
 	public abstract fun remove-eNSUWrY (Ljava/lang/String;Z)Z
 	public abstract fun trim (JF)J
 }
 
 public final class com/apollographql/cache/normalized/api/NormalizedCache$Companion {
-	public final fun prettifyDump (Ljava/util/Map;)Ljava/lang/String;
+	public final fun prettifyDump (Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun prettifyDump$default (Lcom/apollographql/cache/normalized/api/NormalizedCache$Companion;Ljava/util/Map;ZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class com/apollographql/cache/normalized/api/NormalizedCache$DefaultImpls {

--- a/normalized-cache/api/normalized-cache.klib.api
+++ b/normalized-cache/api/normalized-cache.klib.api
@@ -62,7 +62,7 @@ abstract interface com.apollographql.cache.normalized.api/NormalizedCache : com.
     open fun trim(kotlin/Long, kotlin/Float = ...): kotlin/Long // com.apollographql.cache.normalized.api/NormalizedCache.trim|trim(kotlin.Long;kotlin.Float){}[0]
 
     final object Companion { // com.apollographql.cache.normalized.api/NormalizedCache.Companion|null[0]
-        final fun prettifyDump(kotlin.collections/Map<kotlin.reflect/KClass<*>, kotlin.collections/Map<com.apollographql.cache.normalized.api/CacheKey, com.apollographql.cache.normalized.api/Record>>): kotlin/String // com.apollographql.cache.normalized.api/NormalizedCache.Companion.prettifyDump|prettifyDump(kotlin.collections.Map<kotlin.reflect.KClass<*>,kotlin.collections.Map<com.apollographql.cache.normalized.api.CacheKey,com.apollographql.cache.normalized.api.Record>>){}[0]
+        final fun prettifyDump(kotlin.collections/Map<kotlin.reflect/KClass<*>, kotlin.collections/Map<com.apollographql.cache.normalized.api/CacheKey, com.apollographql.cache.normalized.api/Record>>, kotlin/Boolean = ...): kotlin/String // com.apollographql.cache.normalized.api/NormalizedCache.Companion.prettifyDump|prettifyDump(kotlin.collections.Map<kotlin.reflect.KClass<*>,kotlin.collections.Map<com.apollographql.cache.normalized.api.CacheKey,com.apollographql.cache.normalized.api.Record>>;kotlin.Boolean){}[0]
     }
 }
 

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/NormalizedCache.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/NormalizedCache.kt
@@ -86,23 +86,28 @@ interface NormalizedCache : ReadOnlyNormalizedCache {
 
   companion object {
     @JvmStatic
-    fun prettifyDump(dump: Map<@JvmSuppressWildcards KClass<*>, Map<CacheKey, Record>>): String = dump.prettifyDump()
+    fun prettifyDump(dump: Map<@JvmSuppressWildcards KClass<*>, Map<CacheKey, Record>>, showMetadata: Boolean = false): String =
+      dump.prettifyDump(showMetadata = showMetadata)
 
-    private fun Any?.prettifyDump(level: Int = 0): String {
+    private fun Any?.prettifyDump(level: Int = 0, showMetadata: Boolean): String {
       return buildString {
         when (this@prettifyDump) {
           is Record -> {
-            append("{\n")
-            indent(level + 1)
-            append("fields: ")
-            append(fields.prettifyDump(level + 1))
-            append("\n")
-            indent(level + 1)
-            append("metadata: ")
-            append(metadata.prettifyDump(level + 1))
-            append("\n")
-            indent(level)
-            append("}")
+            if (showMetadata) {
+              append("{\n")
+              indent(level + 1)
+              append("fields: ")
+              append(fields.prettifyDump(level + 1, showMetadata))
+              append("\n")
+              indent(level + 1)
+              append("metadata: ")
+              append(metadata.prettifyDump(level + 1, showMetadata))
+              append("\n")
+              indent(level)
+              append("}")
+            } else {
+              append(fields.prettifyDump(level, showMetadata))
+            }
           }
 
           is List<*> -> {
@@ -111,7 +116,7 @@ interface NormalizedCache : ReadOnlyNormalizedCache {
               append("\n")
               for (value in this@prettifyDump) {
                 indent(level + 1)
-                append(value.prettifyDump(level + 1))
+                append(value.prettifyDump(level + 1, showMetadata))
                 append("\n")
               }
               indent(level)
@@ -132,7 +137,7 @@ interface NormalizedCache : ReadOnlyNormalizedCache {
                 }
                 )
                 append(": ")
-                append(value.prettifyDump(level + 1))
+                append(value.prettifyDump(level + 1, showMetadata))
                 append("\n")
               }
               indent(level)


### PR DESCRIPTION
Fix for #119, which was pretty much already implemented but not for all operations.

Also (unrelated): tweak `prettifyDump()` to not show metadata by default.