### PR TITLE
Support simple list cases in FieldPolicyCacheResolver

### DIFF
--- a/tests/normalized-cache/src/commonMain/graphql/declarativecache/extra.graphqls
+++ b/tests/normalized-cache/src/commonMain/graphql/declarativecache/extra.graphqls
@@ -2,7 +2,10 @@ extend type Author @typePolicy(keyFields: "firstName lastName")
 
 extend type Book @typePolicy(keyFields: "isbn")
 
-extend type Query @fieldPolicy(forField: "book", keyArgs: "isbn") @fieldPolicy(forField: "author", keyArgs: "firstName lastName")
+extend type Query
+@fieldPolicy(forField: "book", keyArgs: "isbn")
+@fieldPolicy(forField: "author", keyArgs: "firstName lastName")
+@fieldPolicy(forField: "books", keyArgs: "isbns")
 
 interface Node @typePolicy(keyFields: "id") {
   id: ID!

--- a/tests/normalized-cache/src/commonTest/kotlin/declarativecache/DeclarativeCacheTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/declarativecache/DeclarativeCacheTest.kt
@@ -92,6 +92,20 @@ class DeclarativeCacheTest {
   }
 
   @Test
+  fun fieldPolicyWithLists() = runTest {
+    val cacheManager = CacheManager(MemoryCacheFactory())
+    cacheManager.writeOperation(GetPromoBookQuery(), GetPromoBookQuery.Data(GetPromoBookQuery.PromoBook(title = "Promo", isbn = "42", __typename = "Book")))
+    cacheManager.writeOperation(GetOtherBookQuery(), GetOtherBookQuery.Data(GetOtherBookQuery.OtherBook(isbn = "43", title = "Other Book", __typename = "Book")))
+
+    val booksQuery = GetBooksQuery(listOf("42", "43"))
+    val booksCacheResponse = cacheManager.readOperation(booksQuery)
+    val booksData = booksCacheResponse.data!!
+    assertEquals(2, booksData.books.size)
+    assertEquals(GetBooksQuery.Book("Promo", "42", "Book"), booksData.books[0])
+    assertEquals(GetBooksQuery.Book("Other Book", "43", "Book"), booksData.books[1])
+  }
+
+  @Test
   fun canResolveListProgrammatically() = runTest {
     val cacheResolver = object : CacheResolver {
       override fun resolveField(context: ResolverContext): Any? {


### PR DESCRIPTION
Handle simple cases like:

```graphql
type Query {
  books(ids: [String!]!)
}
extend type Query @fieldPolicy(forField: "books", keyArgs: "ids")
```

where 
- the field is a flat list
- `keyArgs` is a single arg which is a flat list

Other cases fall back to what we had previously.