### PR TITLE
Don't assume presence of keyFields on @typePolicy

### DIFF
--- a/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/getTypePolicies.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/getTypePolicies.kt
@@ -80,7 +80,7 @@ private fun Schema.validateAndComputeTypePolicy(
 }
 
 private fun GQLDirective.toTypePolicy(): TypePolicy {
-  val keyFields = ((arguments.single { it.name == "keyFields" }.value as GQLStringValue).value
+  val keyFields = (((arguments.singleOrNull { it.name == "keyFields" }?.value as? GQLStringValue)?.value ?: "")
       .parseAsGQLSelections().value?.map { gqlSelection ->
         (gqlSelection as GQLField).name
       } ?: throw SourceAwareException("Apollo: keyArgs should be a selectionSet", sourceLocation))


### PR DESCRIPTION
A bit of an edge case but you're allowed to do `extend type Organization @typePolicy(connectionFields: "repositories")`