### PR TITLE
Use plugin ids directly, makes it easier to use an included build

### DIFF
--- a/tests/cache-control/build.gradle.kts
+++ b/tests/cache-control/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/cache-variables-arguments/build.gradle.kts
+++ b/tests/cache-variables-arguments/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/garbage-collection/build.gradle.kts
+++ b/tests/garbage-collection/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/include-skip-operation-based/build.gradle.kts
+++ b/tests/include-skip-operation-based/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/migration/build.gradle.kts
+++ b/tests/migration/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/models-operation-based-with-interfaces/build.gradle.kts
+++ b/tests/models-operation-based-with-interfaces/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/models-operation-based/build.gradle.kts
+++ b/tests/models-operation-based/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/models-response-based/build.gradle.kts
+++ b/tests/models-response-based/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/normalization-tests/build.gradle.kts
+++ b/tests/normalization-tests/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/normalized-cache/build.gradle.kts
+++ b/tests/normalized-cache/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/number-scalar/build.gradle.kts
+++ b/tests/number-scalar/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/optimistic-data/build.gradle.kts
+++ b/tests/optimistic-data/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/pagination/build.gradle.kts
+++ b/tests/pagination/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/partial-results/build.gradle.kts
+++ b/tests/partial-results/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/schema-changes/build.gradle.kts
+++ b/tests/schema-changes/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {

--- a/tests/store-errors/build.gradle.kts
+++ b/tests/store-errors/build.gradle.kts
@@ -2,7 +2,7 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.apollo)
+  id("com.apollographql.apollo")
 }
 
 kotlin {


### PR DESCRIPTION
Because aliases also contain a version, it will fail to resolve if the root plugin is loaded through dependency substitution with `Cannot apply plugin because it's already on the classpath`

