### PR TITLE
v5 compat

### DIFF
--- a/gradle/repositories.gradle.kts
+++ b/gradle/repositories.gradle.kts
@@ -3,6 +3,7 @@ listOf(pluginManagement.repositories, dependencyResolutionManagement.repositorie
 //    mavenLocal()
 //    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
 //    maven("https://storage.googleapis.com/apollo-previews/m2/")
+    mavenLocal()
     mavenCentral()
     google()
     gradlePluginPortal()

--- a/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/CacheSchemaCodeGenerator.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/CacheSchemaCodeGenerator.kt
@@ -6,7 +6,9 @@ import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.ast.GQLDocument
 import com.apollographql.apollo.ast.Schema
 import com.apollographql.apollo.ast.toSchema
+import com.apollographql.apollo.compiler.ApolloCompiler
 import com.apollographql.apollo.compiler.ApolloCompilerPluginEnvironment
+import com.apollographql.apollo.compiler.ApolloCompilerPluginLogger
 import com.apollographql.apollo.compiler.SchemaCodeGenerator
 import com.apollographql.cache.apollocompilerplugin.VERSION
 import com.squareup.kotlinpoet.ClassName
@@ -58,8 +60,25 @@ internal class CacheSchemaCodeGenerator(
     file.writeTo(outputDirectory)
   }
 
+  private fun ApolloCompilerPluginEnvironment.logger(): ApolloCompiler.Logger {
+    val method = this::class.java.methods.first { it.name == "getLogger" }
+    if (method.returnType.name == "com.apollographql.apollo.compiler.ApolloCompiler\$Logger") {
+      return method.invoke(this) as ApolloCompiler.Logger
+    }
+
+    return logger.toApolloCompilerLogger()
+  }
+
+  private fun ApolloCompilerPluginLogger.toApolloCompilerLogger(): ApolloCompiler.Logger {
+    return object : ApolloCompiler.Logger {
+      override fun warning(message: String) {
+        return this@toApolloCompilerLogger.error(message)
+      }
+    }
+  }
+
   private fun maxAgeProperty(schema: Schema): PropertySpec {
-    val maxAges = schema.getMaxAges(environment.logger)
+    val maxAges = schema.getMaxAges(environment.logger())
     val initializer = CodeBlock.builder().apply {
       add("mapOf(\n")
       withIndent {

--- a/normalized-cache-apollo-compiler-plugin/src/test/kotlin/com/apollographql/cache/apollocompilerplugin/internal/ApolloVersionTest.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/test/kotlin/com/apollographql/cache/apollocompilerplugin/internal/ApolloVersionTest.kt
@@ -1,27 +1,115 @@
 package com.apollographql.cache.apollocompilerplugin.internal
 
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+/**
+ * Those tests all share the same `build/testProject` directory and are therefore synchronized.
+ */
 class ApolloVersionTest {
 
   @Test
-  fun failsBelowApollo4_3() {
-    val workingDir = File("build/testProject")
-
-    workingDir.deleteRecursively()
-    File("test-data/testProject").copyRecursively(workingDir)
-    try {
-      GradleRunner.create()
-          .withProjectDir(workingDir)
-          .withDebug(true)
-          .withArguments("generateServiceApolloSources")
-          .build()
-    } catch (e: UnexpectedBuildFailure) {
-      assertTrue(e.message!!.contains("The Apollo Cache compiler plugin requires Apollo Kotlin version 4.3.0 or higher (found 4.2.0)"))
+  @Synchronized
+  fun apollo_4_2_fails() {
+    withProject {
+      it.version("4.2.0")
+    }.assertFailure("generateServiceApolloSources") {
+      assertTrue(it.message!!.contains("The Apollo Cache compiler plugin requires Apollo Kotlin version 4.3.0 or higher (found 4.2.0)"))
     }
   }
+
+  @Test
+  @Synchronized
+  fun apollo_4_3_succeeds() {
+    withProject {
+      it.version("4.3.0")
+    }.assertSuccess("build")
+  }
+
+  @Test
+  @Synchronized
+  @Ignore("There is no 5.0.0 release yet")
+  fun apollo_5_0_succeeds() {
+    withProject {
+      it.version("5.0.0-SNAPSHOT")
+    }.assertSuccess("build")
+  }
+
+  @Test
+  @Synchronized
+  fun apollo_4_3_shows_error_message() {
+    withProject {
+      it.version("4.3.0")
+      it.addBadCacheControl()
+    }.assertFailure("generateServiceApolloSources") {
+      assertTrue(it.message!!.contains("`maxAge` must not be negative"))
+    }
+  }
+
+  @Test
+  @Synchronized
+  @Ignore("There is no 5.0.0 release yet")
+  fun apollo_5_0_shows_error_message() {
+    withProject {
+      it.version("5.0.0-SNAPSHOT")
+      it.addBadCacheControl()
+    }.assertFailure("generateServiceApolloSources") {
+      assertTrue(it.message!!.contains("`maxAge` must not be negative"))
+    }
+  }
+}
+
+private fun withProject(block: (File) -> Unit): File {
+  val workingDir = File("build/testProject")
+
+  workingDir.deleteRecursively()
+  File("test-data/testProject").copyRecursively(workingDir)
+  block(workingDir)
+  return workingDir
+}
+
+private fun File.addBadCacheControl() {
+  resolve("src/main/graphql/schema.graphqls").replace("# DIRECTIVE_PLACEHOLDER", "@cacheControl(maxAge: -10)")
+}
+
+private fun File.version(version: String) {
+  resolve("build.gradle.kts").replace("4.2.0", version)
+}
+private fun File.assertFailure(taskName: String, onFailure: (UnexpectedBuildFailure) -> Unit) {
+  newRunner().assertFailure(taskName, onFailure)
+}
+
+private fun File.assertSuccess(taskName: String) {
+  newRunner().assertSuccess(taskName)
+}
+
+private fun File.newRunner(): GradleRunner {
+  return GradleRunner.create()
+    .withProjectDir(this)
+    .withDebug(true)
+}
+
+private fun GradleRunner.assertFailure(taskName: String, onFailure: (UnexpectedBuildFailure) -> Unit) {
+  try {
+    withArguments(taskName)
+      .build()
+  } catch (e: UnexpectedBuildFailure) {
+    onFailure(e)
+  }
+}
+
+private fun GradleRunner.assertSuccess(taskName: String) {
+  withArguments(taskName)
+    .build().apply {
+      assertEquals(TaskOutcome.SUCCESS, task(":$taskName")!!.outcome)
+    }
+}
+
+private fun File.replace(str: String, replacement: String) {
+  writeText(readText().replace(str, replacement))
 }

--- a/normalized-cache-apollo-compiler-plugin/src/test/kotlin/com/apollographql/cache/apollocompilerplugin/internal/GetMaxAgesTest.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/test/kotlin/com/apollographql/cache/apollocompilerplugin/internal/GetMaxAgesTest.kt
@@ -8,6 +8,8 @@ import com.apollographql.apollo.ast.builtinForeignSchemas
 import com.apollographql.apollo.ast.internal.SchemaValidationOptions
 import com.apollographql.apollo.ast.parseAsGQLDocument
 import com.apollographql.apollo.ast.validateAsSchema
+import com.apollographql.apollo.compiler.ApolloCompiler
+import com.apollographql.apollo.compiler.ApolloCompilerPlugin
 import com.apollographql.apollo.compiler.ApolloCompilerPluginLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -70,20 +72,8 @@ class GetMaxAgesTest {
         )
         .getOrThrow()
         .getMaxAges(
-            object : ApolloCompilerPluginLogger {
-              override fun error(message: String) {
-                fail()
-              }
-
-              override fun info(message: String) {
-                fail()
-              }
-
-              override fun logging(message: String) {
-                fail()
-              }
-
-              override fun warn(message: String) {
+            object : ApolloCompiler.Logger {
+              override fun warning(message: String) {
                 fail()
               }
             }
@@ -152,23 +142,11 @@ class GetMaxAgesTest {
           )
           .getOrThrow()
           .getMaxAges(
-              object : ApolloCompilerPluginLogger {
-                override fun error(message: String) {
-                  errors += message
-                }
-
-                override fun info(message: String) {
-                  fail()
-                }
-
-                override fun logging(message: String) {
-                  fail()
-                }
-
-                override fun warn(message: String) {
-                  fail()
-                }
+            object : ApolloCompiler.Logger {
+              override fun warning(message: String) {
+                fail()
               }
+            }
           )
     }
     val expectedErrors = listOf(

--- a/normalized-cache-apollo-compiler-plugin/test-data/testProject/build.gradle.kts
+++ b/normalized-cache-apollo-compiler-plugin/test-data/testProject/build.gradle.kts
@@ -11,3 +11,9 @@ apollo {
     }
   }
 }
+
+dependencies {
+  implementation("com.apollographql.apollo:apollo-api")
+  implementation("com.apollographql.cache:normalized-cache")
+  testImplementation(libs.kotlin.test)
+}

--- a/normalized-cache-apollo-compiler-plugin/test-data/testProject/src/main/graphql/schema.graphqls
+++ b/normalized-cache-apollo-compiler-plugin/test-data/testProject/src/main/graphql/schema.graphqls
@@ -1,9 +1,14 @@
+extend schema @link(url: "https://specs.apollo.dev/cache/v0.1/", import: ["@cacheControl"])
+
 type Query {
     product: Product
     foo: Int
 }
 
-type Product @typePolicy(keyFields: "id"){
+type Product
+    @typePolicy(keyFields: "id")
+    # DIRECTIVE_PLACEHOLDER
+{
     id: ID!
     price: Float
 }

--- a/normalized-cache-apollo-compiler-plugin/test-data/testProject/src/test/kotlin/MainTest.kt
+++ b/normalized-cache-apollo-compiler-plugin/test-data/testProject/src/test/kotlin/MainTest.kt
@@ -1,0 +1,10 @@
+import com.example.cache.Cache
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MainTest {
+  @Test
+  fun mainTest() {
+    assertEquals("id", Cache.typePolicies.get("Product")?.keyFields?.single())
+  }
+}


### PR DESCRIPTION
- **Documentation: add section about the compiler plugin and trimming + improve readme (#171)**
- **Update Apollo compiler plugin to 4.3 API (#169)**
- **Release 1.0.0-alpha.3 (#173)**
- **Version is now 1.0.0-alpha.4-SNAPSHOT**
- **Use latest version in samples (#174)**
- **v5 tests and compatibility**
