### PR TITLE
Load all records in one query when merging, when chaining caches

### DIFF
--- a/normalized-cache/api/normalized-cache.api
+++ b/normalized-cache/api/normalized-cache.api
@@ -280,6 +280,7 @@ public final class com/apollographql/cache/normalized/api/ApolloCacheHeaders {
 	public static final field MAX_STALE Ljava/lang/String;
 	public static final field MEMORY_CACHE_ONLY Ljava/lang/String;
 	public static final field RECEIVED_DATE Ljava/lang/String;
+	public static final field SKIP_MERGE Ljava/lang/String;
 	public static final field STALE Ljava/lang/String;
 }
 

--- a/normalized-cache/api/normalized-cache.klib.api
+++ b/normalized-cache/api/normalized-cache.klib.api
@@ -554,6 +554,8 @@ final object com.apollographql.cache.normalized.api/ApolloCacheHeaders { // com.
         final fun <get-MEMORY_CACHE_ONLY>(): kotlin/String // com.apollographql.cache.normalized.api/ApolloCacheHeaders.MEMORY_CACHE_ONLY.<get-MEMORY_CACHE_ONLY>|<get-MEMORY_CACHE_ONLY>(){}[0]
     final const val RECEIVED_DATE // com.apollographql.cache.normalized.api/ApolloCacheHeaders.RECEIVED_DATE|{}RECEIVED_DATE[0]
         final fun <get-RECEIVED_DATE>(): kotlin/String // com.apollographql.cache.normalized.api/ApolloCacheHeaders.RECEIVED_DATE.<get-RECEIVED_DATE>|<get-RECEIVED_DATE>(){}[0]
+    final const val SKIP_MERGE // com.apollographql.cache.normalized.api/ApolloCacheHeaders.SKIP_MERGE|{}SKIP_MERGE[0]
+        final fun <get-SKIP_MERGE>(): kotlin/String // com.apollographql.cache.normalized.api/ApolloCacheHeaders.SKIP_MERGE.<get-SKIP_MERGE>|<get-SKIP_MERGE>(){}[0]
     final const val STALE // com.apollographql.cache.normalized.api/ApolloCacheHeaders.STALE|{}STALE[0]
         final fun <get-STALE>(): kotlin/String // com.apollographql.cache.normalized.api/ApolloCacheHeaders.STALE.<get-STALE>|<get-STALE>(){}[0]
 }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/ApolloCacheHeaders.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/ApolloCacheHeaders.kt
@@ -46,4 +46,9 @@ object ApolloCacheHeaders {
    * True if field errors are allowed to replace cached values.
    */
   const val ERRORS_REPLACE_CACHED_VALUES = "apollo-errors-replace-cached-values"
+
+  /**
+   * When true, [NormalizedCache.merge] skips merging records with the existing ones, instead, they are inserted as-is.
+   */
+  const val SKIP_MERGE = "skip-merge"
 }


### PR DESCRIPTION
When chaining Memory+SQL caches, `merge(Collection<Record>)` was fetching records one by one from the SQL cache (plus actual record merging was done twice), which is suboptimal. Instead, fetch them in one query, and do the merging once.