### PR TITLE
Use MIT license with a SPDX compatible identifier

### DIFF
--- a/librarian.root.properties
+++ b/librarian.root.properties
@@ -9,7 +9,7 @@ pom.version=1.0.0-alpha.8-SNAPSHOT
 pom.description=Apollo Kotlin Normalized Cache
 pom.vcsUrl=https://github.com/apollographql/apollo-kotlin-normalized-cache
 pom.developer=Apollo Kotlin Normalized Cache contributors
-pom.license=MIT License
+pom.license=MIT
 
 gcs.bucket=apollo-previews
 gcs.prefix=m2


### PR DESCRIPTION
Should fix issue #235