### PR TITLE
Use a mutex in MemoryCache even when there is no nextCache

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Mutex.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Mutex.kt
@@ -1,17 +1,17 @@
 package com.apollographql.cache.normalized.internal
 
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.coroutineContext
 
 // Based on https://gist.github.com/elizarov/9a48b9709ffd508909d34fab6786acfe
 // See also https://elizarov.medium.com/phantom-of-the-coroutine-afc63b03a131
 internal suspend fun <T> Mutex.withReentrantLock(block: suspend () -> T): T {
   val key = ReentrantMutexContextKey(this)
   // call block directly when this mutex is already locked in the context
-  if (coroutineContext[key] != null) return block()
+  if (currentCoroutineContext()[key] != null) return block()
   // otherwise add it to the context and lock the mutex
   return withContext(ReentrantMutexContextElement(key)) {
     withLock { block() }


### PR DESCRIPTION
Fixes #259.

A mutex was used when `nextCache` was set, so both caches are synchronized. But as revealed in #259, it is also needed independently of `nextCache` to ensure `merge` (which does reads and writes) is an atomic operation.

## Performance impact

Non-concurrent benchmarks [`CacheIncubatingTests.cacheOperationMemory` and `CacheIncubatingTests.cacheLargeListMemory`](https://github.com/apollographql/apollo-kotlin/blob/2777c89280cf3b2cabdfe209d121b8661536cea1/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo/benchmark/CacheIncubatingTests.kt#L25): no noticeable impact.

However [`ApolloStoreIncubatingTests.concurrentReadWritesMemory`](https://github.com/apollographql/apollo-kotlin/blob/2777c89280cf3b2cabdfe209d121b8661536cea1/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo/benchmark/ApolloStoreIncubatingTests.kt#L23) which makes concurrent read/writes in 10 threads take **1.7x** longer. This is to be expected since operations that previously happened in parallel are now serialized.