### PR TITLE
Disallow same db file name to be used multiple times at the same time

### DIFF
--- a/normalized-cache-sqlite/api/android/normalized-cache-sqlite.api
+++ b/normalized-cache-sqlite/api/android/normalized-cache-sqlite.api
@@ -11,6 +11,7 @@ public final class com/apollographql/cache/normalized/sql/ApolloInitializer$Comp
 
 public final class com/apollographql/cache/normalized/sql/SqlNormalizedCache : com/apollographql/cache/normalized/api/NormalizedCache {
 	public fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun dump (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun loadRecord-7OwBRqc (Ljava/lang/String;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun loadRecords (Ljava/util/Collection;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -24,6 +25,7 @@ public final class com/apollographql/cache/normalized/sql/SqlNormalizedCache : c
 
 public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactoryKt {
 	public static final fun SqlNormalizedCacheFactory (Lapp/cash/sqldelight/db/SqlDriver;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
+	public static final fun SqlNormalizedCacheFactory (Lapp/cash/sqldelight/db/SqlDriver;Ljava/lang/String;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 }
 
 public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory_androidKt {

--- a/normalized-cache-sqlite/api/jvm/normalized-cache-sqlite.api
+++ b/normalized-cache-sqlite/api/jvm/normalized-cache-sqlite.api
@@ -1,5 +1,6 @@
 public final class com/apollographql/cache/normalized/sql/SqlNormalizedCache : com/apollographql/cache/normalized/api/NormalizedCache {
 	public fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun dump (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun loadRecord-7OwBRqc (Ljava/lang/String;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun loadRecords (Ljava/util/Collection;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -13,6 +14,7 @@ public final class com/apollographql/cache/normalized/sql/SqlNormalizedCache : c
 
 public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactoryKt {
 	public static final fun SqlNormalizedCacheFactory (Lapp/cash/sqldelight/db/SqlDriver;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
+	public static final fun SqlNormalizedCacheFactory (Lapp/cash/sqldelight/db/SqlDriver;Ljava/lang/String;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 }
 
 public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory_jvmKt {
@@ -20,7 +22,6 @@ public final class com/apollographql/cache/normalized/sql/SqlNormalizedCacheFact
 	public static final fun SqlNormalizedCacheFactory (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static final fun SqlNormalizedCacheFactory (Ljava/lang/String;Ljava/util/Properties;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 	public static synthetic fun SqlNormalizedCacheFactory$default (Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
-	public static synthetic fun SqlNormalizedCacheFactory$default (Ljava/lang/String;Ljava/util/Properties;ILjava/lang/Object;)Lcom/apollographql/cache/normalized/api/NormalizedCacheFactory;
 }
 
 public final class com/apollographql/cache/normalized/sql/VersionKt {

--- a/normalized-cache-sqlite/api/normalized-cache-sqlite.klib.api
+++ b/normalized-cache-sqlite/api/normalized-cache-sqlite.klib.api
@@ -89,6 +89,7 @@ final class com.apollographql.cache.normalized.sql.internal.record/SelectRecords
 final class com.apollographql.cache.normalized.sql/SqlNormalizedCache : com.apollographql.cache.normalized.api/NormalizedCache { // com.apollographql.cache.normalized.sql/SqlNormalizedCache|null[0]
     final fun sizeOfRecord(com.apollographql.cache.normalized.api/Record): kotlin/Int // com.apollographql.cache.normalized.sql/SqlNormalizedCache.sizeOfRecord|sizeOfRecord(com.apollographql.cache.normalized.api.Record){}[0]
     final suspend fun clearAll() // com.apollographql.cache.normalized.sql/SqlNormalizedCache.clearAll|clearAll(){}[0]
+    final suspend fun close() // com.apollographql.cache.normalized.sql/SqlNormalizedCache.close|close(){}[0]
     final suspend fun dump(): kotlin.collections/Map<kotlin.reflect/KClass<*>, kotlin.collections/Map<com.apollographql.cache.normalized.api/CacheKey, com.apollographql.cache.normalized.api/Record>> // com.apollographql.cache.normalized.sql/SqlNormalizedCache.dump|dump(){}[0]
     final suspend fun loadRecord(com.apollographql.cache.normalized.api/CacheKey, com.apollographql.cache.normalized.api/CacheHeaders): com.apollographql.cache.normalized.api/Record? // com.apollographql.cache.normalized.sql/SqlNormalizedCache.loadRecord|loadRecord(com.apollographql.cache.normalized.api.CacheKey;com.apollographql.cache.normalized.api.CacheHeaders){}[0]
     final suspend fun loadRecords(kotlin.collections/Collection<com.apollographql.cache.normalized.api/CacheKey>, com.apollographql.cache.normalized.api/CacheHeaders): kotlin.collections/Collection<com.apollographql.cache.normalized.api/Record> // com.apollographql.cache.normalized.sql/SqlNormalizedCache.loadRecords|loadRecords(kotlin.collections.Collection<com.apollographql.cache.normalized.api.CacheKey>;com.apollographql.cache.normalized.api.CacheHeaders){}[0]
@@ -103,6 +104,7 @@ final val com.apollographql.cache.normalized.sql/VERSION // com.apollographql.ca
     final fun <get-VERSION>(): kotlin/String // com.apollographql.cache.normalized.sql/VERSION.<get-VERSION>|<get-VERSION>(){}[0]
 
 final fun com.apollographql.cache.normalized.sql/SqlNormalizedCacheFactory(app.cash.sqldelight.db/SqlDriver): com.apollographql.cache.normalized.api/NormalizedCacheFactory // com.apollographql.cache.normalized.sql/SqlNormalizedCacheFactory|SqlNormalizedCacheFactory(app.cash.sqldelight.db.SqlDriver){}[0]
+final fun com.apollographql.cache.normalized.sql/SqlNormalizedCacheFactory(app.cash.sqldelight.db/SqlDriver, kotlin/String?): com.apollographql.cache.normalized.api/NormalizedCacheFactory // com.apollographql.cache.normalized.sql/SqlNormalizedCacheFactory|SqlNormalizedCacheFactory(app.cash.sqldelight.db.SqlDriver;kotlin.String?){}[0]
 final fun com.apollographql.cache.normalized.sql/SqlNormalizedCacheFactory(kotlin/String? = ...): com.apollographql.cache.normalized.api/NormalizedCacheFactory // com.apollographql.cache.normalized.sql/SqlNormalizedCacheFactory|SqlNormalizedCacheFactory(kotlin.String?){}[0]
 
 // Targets: [apple]

--- a/normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.android.kt
+++ b/normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.android.kt
@@ -48,7 +48,7 @@ fun SqlNormalizedCacheFactory(
     }
   }
   return SqlNormalizedCacheFactory(
-      AndroidSqliteDriver(
+      driver = AndroidSqliteDriver(
           schema = synchronousSchema,
           context = context.applicationContext,
           name = filePath,
@@ -62,6 +62,7 @@ fun SqlNormalizedCacheFactory(
           useNoBackupDirectory = useNoBackupDirectory,
           windowSizeBytes = windowSizeBytes,
       ),
+      name = filePath,
   )
 }
 

--- a/normalized-cache-sqlite/src/appleMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.apple.kt
+++ b/normalized-cache-sqlite/src/appleMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.apple.kt
@@ -17,7 +17,7 @@ import com.apollographql.cache.normalized.sql.internal.record.SqlRecordDatabase
 fun SqlNormalizedCacheFactory(
     name: String?,
     baseDir: String?,
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(createDriver(name, baseDir))
+): NormalizedCacheFactory = SqlNormalizedCacheFactory(createDriver(name, baseDir), name)
 
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory = SqlNormalizedCacheFactory(name, null)
 

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
@@ -190,4 +190,8 @@ class SqlNormalizedCache internal constructor(
       return -1
     }
   }
+
+  override suspend fun close() {
+    recordDatabase.close()
+  }
 }

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -15,12 +15,15 @@ import com.apollographql.cache.normalized.sql.internal.RecordDatabase
  * - on MacOS, it will use "Application Support/databases/name"
  * - on the JVM, it will use "System.getProperty("user.home")/.apollo"
  * - on JS/Wasm, this argument is unused
+ *
  * Default: "apollo.db"
  */
 expect fun SqlNormalizedCacheFactory(name: String? = "apollo.db"): NormalizedCacheFactory
 
-fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory = object : NormalizedCacheFactory() {
+fun SqlNormalizedCacheFactory(driver: SqlDriver): NormalizedCacheFactory = SqlNormalizedCacheFactory(driver, name = "apollo.db")
+
+fun SqlNormalizedCacheFactory(driver: SqlDriver, name: String?): NormalizedCacheFactory = object : NormalizedCacheFactory() {
   override fun create(): NormalizedCache {
-    return SqlNormalizedCache(RecordDatabase(driver))
+    return SqlNormalizedCache(RecordDatabase(driver, name))
   }
 }

--- a/normalized-cache-sqlite/src/jsCommonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jsCommon.kt
+++ b/normalized-cache-sqlite/src/jsCommonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jsCommon.kt
@@ -15,6 +15,6 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
  * See [the SQLDelight documentation](https://sqldelight.github.io/sqldelight/2.1.0/js_sqlite/sqljs_worker/).
  */
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory {
-  return SqlNormalizedCacheFactory(createDefaultWebWorkerDriver())
+  return SqlNormalizedCacheFactory(createDefaultWebWorkerDriver(), name = null)
 }
 

--- a/normalized-cache-sqlite/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jvm.kt
+++ b/normalized-cache-sqlite/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jvm.kt
@@ -12,8 +12,8 @@ import java.util.Properties
  */
 fun SqlNormalizedCacheFactory(
     url: String,
-    properties: Properties = Properties(),
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(JdbcSqliteDriver(url, properties))
+    properties: Properties,
+): NormalizedCacheFactory = SqlNormalizedCacheFactory(JdbcSqliteDriver(url, properties), name = null)
 
 /**
  * @param name the name of the database or null for an in-memory database
@@ -24,7 +24,7 @@ fun SqlNormalizedCacheFactory(
 fun SqlNormalizedCacheFactory(
     name: String?,
     baseDir: String?,
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(JdbcSqliteDriver(name.toUrl(baseDir), Properties()))
+): NormalizedCacheFactory = SqlNormalizedCacheFactory(JdbcSqliteDriver(name.toUrl(baseDir), Properties()), name = name)
 
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory = SqlNormalizedCacheFactory(name, null)
 

--- a/normalized-cache/api/normalized-cache.api
+++ b/normalized-cache/api/normalized-cache.api
@@ -611,6 +611,7 @@ public final class com/apollographql/cache/normalized/api/NormalizedCache$Compan
 }
 
 public final class com/apollographql/cache/normalized/api/NormalizedCache$DefaultImpls {
+	public static fun close (Lcom/apollographql/cache/normalized/api/NormalizedCache;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun sizeOfRecord (Lcom/apollographql/cache/normalized/api/NormalizedCache;Lcom/apollographql/cache/normalized/api/Record;)I
 	public static fun trim (Lcom/apollographql/cache/normalized/api/NormalizedCache;JFLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun trim$default (Lcom/apollographql/cache/normalized/api/NormalizedCache;JFLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -622,6 +623,7 @@ public abstract class com/apollographql/cache/normalized/api/NormalizedCacheFact
 }
 
 public abstract interface class com/apollographql/cache/normalized/api/ReadOnlyNormalizedCache {
+	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun dump (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun loadRecord-7OwBRqc (Ljava/lang/String;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun loadRecords (Ljava/util/Collection;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -629,6 +631,7 @@ public abstract interface class com/apollographql/cache/normalized/api/ReadOnlyN
 }
 
 public final class com/apollographql/cache/normalized/api/ReadOnlyNormalizedCache$DefaultImpls {
+	public static fun close (Lcom/apollographql/cache/normalized/api/ReadOnlyNormalizedCache;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun sizeOfRecord (Lcom/apollographql/cache/normalized/api/ReadOnlyNormalizedCache;Lcom/apollographql/cache/normalized/api/Record;)I
 }
 
@@ -756,6 +759,7 @@ public final class com/apollographql/cache/normalized/memory/MemoryCache : com/a
 	public fun <init> (Lcom/apollographql/cache/normalized/api/NormalizedCache;IJ)V
 	public synthetic fun <init> (Lcom/apollographql/cache/normalized/api/NormalizedCache;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun dump (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun loadRecord-7OwBRqc (Ljava/lang/String;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun loadRecords (Ljava/util/Collection;Lcom/apollographql/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/normalized-cache/api/normalized-cache.klib.api
+++ b/normalized-cache/api/normalized-cache.klib.api
@@ -75,6 +75,7 @@ abstract interface com.apollographql.cache.normalized.api/ReadOnlyNormalizedCach
     abstract suspend fun loadRecord(com.apollographql.cache.normalized.api/CacheKey, com.apollographql.cache.normalized.api/CacheHeaders): com.apollographql.cache.normalized.api/Record? // com.apollographql.cache.normalized.api/ReadOnlyNormalizedCache.loadRecord|loadRecord(com.apollographql.cache.normalized.api.CacheKey;com.apollographql.cache.normalized.api.CacheHeaders){}[0]
     abstract suspend fun loadRecords(kotlin.collections/Collection<com.apollographql.cache.normalized.api/CacheKey>, com.apollographql.cache.normalized.api/CacheHeaders): kotlin.collections/Collection<com.apollographql.cache.normalized.api/Record> // com.apollographql.cache.normalized.api/ReadOnlyNormalizedCache.loadRecords|loadRecords(kotlin.collections.Collection<com.apollographql.cache.normalized.api.CacheKey>;com.apollographql.cache.normalized.api.CacheHeaders){}[0]
     open fun sizeOfRecord(com.apollographql.cache.normalized.api/Record): kotlin/Int // com.apollographql.cache.normalized.api/ReadOnlyNormalizedCache.sizeOfRecord|sizeOfRecord(com.apollographql.cache.normalized.api.Record){}[0]
+    open suspend fun close() // com.apollographql.cache.normalized.api/ReadOnlyNormalizedCache.close|close(){}[0]
 }
 
 abstract interface com.apollographql.cache.normalized.api/RecordMerger { // com.apollographql.cache.normalized.api/RecordMerger|null[0]

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/ReadOnlyNormalizedCache.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/ReadOnlyNormalizedCache.kt
@@ -28,4 +28,6 @@ interface ReadOnlyNormalizedCache {
    * This is an optional operation that can be implemented by the caches for debug purposes, otherwise it defaults to `-1`, meaning unknown size.
    */
   fun sizeOfRecord(record: Record): Int = -1
+
+  suspend fun close() {}
 }


### PR DESCRIPTION
Addresses #139

Using multiple `SqlNormalizedCache` initialized with the same file name will throw unless `close()` is called first.