### PR TITLE
Fail fast when a key arg has no value

### DIFF
--- a/tests/cache-configuration/build.gradle.kts
+++ b/tests/cache-configuration/build.gradle.kts
@@ -1,0 +1,49 @@
+import com.apollographql.apollo.annotations.ApolloExperimental
+
+plugins {
+  alias(libs.plugins.kotlin.multiplatform)
+  id("com.apollographql.apollo")
+}
+
+kotlin {
+  configureKmp(
+      withJs = emptySet(),
+      withWasm = emptySet(),
+      withAndroid = false,
+      withApple = AppleTargets.Host,
+  )
+
+  sourceSets {
+    getByName("commonMain") {
+      dependencies {
+        implementation(libs.apollo.runtime)
+        implementation("com.apollographql.cache:normalized-cache-sqlite")
+      }
+    }
+
+    getByName("commonTest") {
+      dependencies {
+        implementation("com.apollographql.cache:test-utils")
+        implementation(libs.apollo.mockserver)
+        implementation(libs.kotlin.test)
+      }
+    }
+
+    getByName("jvmTest") {
+      dependencies {
+        implementation(libs.slf4j.nop)
+      }
+    }
+  }
+}
+
+apollo {
+  service("service") {
+    packageName.set("test")
+
+    @OptIn(ApolloExperimental::class)
+    plugin("com.apollographql.cache:normalized-cache-apollo-compiler-plugin") {
+      argument("packageName", packageName.get())
+    }
+  }
+}

--- a/tests/cache-configuration/src/commonMain/graphql/extra.graphqls
+++ b/tests/cache-configuration/src/commonMain/graphql/extra.graphqls
@@ -1,0 +1,7 @@
+extend schema
+@link(
+  url: "https://specs.apollo.dev/kotlin_labs/v0.5",
+  import: ["@typePolicy", "@fieldPolicy"]
+)
+
+extend type User @typePolicy(keyFields: "id")

--- a/tests/cache-configuration/src/commonMain/graphql/operation.graphql
+++ b/tests/cache-configuration/src/commonMain/graphql/operation.graphql
@@ -1,0 +1,7 @@
+query UserByIdQuery($id: ID!) {
+  user(id: $id) {
+    id
+    firstName
+    lastName
+  }
+}

--- a/tests/cache-configuration/src/commonMain/graphql/schema.graphqls
+++ b/tests/cache-configuration/src/commonMain/graphql/schema.graphqls
@@ -1,0 +1,10 @@
+type Query {
+  user(id: ID!): User
+  user2(id: ID!): User
+}
+
+type User {
+  id: ID!
+  firstName: String!
+  lastName: String!
+}

--- a/tests/cache-configuration/src/commonTest/kotlin/test/CacheConfigurationTest.kt
+++ b/tests/cache-configuration/src/commonTest/kotlin/test/CacheConfigurationTest.kt
@@ -1,0 +1,268 @@
+package test
+
+import com.apollographql.apollo.ApolloClient.Builder
+import com.apollographql.apollo.exception.CacheMissException
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.api.CacheKey
+import com.apollographql.cache.normalized.api.FieldPolicies
+import com.apollographql.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.runTest
+import com.apollographql.mockserver.MockServer
+import com.apollographql.mockserver.enqueueString
+import okio.use
+import test.UserByIdQuery.Data
+import test.UserByIdQuery.User
+import test.cache.Cache
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.Duration
+
+class CacheConfigurationTest {
+  private lateinit var mockServer: MockServer
+
+  private fun setUp() {
+    mockServer = MockServer()
+  }
+
+  private fun tearDown() {
+    mockServer.close()
+  }
+
+  @Test
+  fun noKeyArgCacheHit() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueueString(
+        // language=JSON
+        """
+          {
+            "data": {
+              "user": {
+                "__typename": "User",
+                "id": "42",
+                "firstName": "John",
+                "lastName": "Smith"
+              }
+            }
+          }
+        """.trimIndent(),
+    )
+    Builder()
+        .serverUrl(mockServer.url())
+        .configureCache(
+            fieldPolicies = emptyMap(),
+        )
+        .build()
+        .use { apolloClient ->
+          val networkResult = apolloClient.query(UserByIdQuery("42"))
+              .fetchPolicy(FetchPolicy.NetworkOnly)
+              .execute()
+          assertEquals(
+              Data(
+                  User(
+                      __typename = "User",
+                      id = "42",
+                      firstName = "John",
+                      lastName = "Smith",
+                  ),
+              ),
+              networkResult.data,
+          )
+
+          val cacheResult = apolloClient.query(UserByIdQuery("42"))
+              .fetchPolicy(FetchPolicy.CacheOnly)
+              .execute()
+          assertEquals(
+              networkResult.data,
+              cacheResult.data,
+          )
+        }
+  }
+
+  @Test
+  fun noKeyArgCacheMiss() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueueString(
+        // language=JSON
+        """
+          {
+            "data": {
+              "user": {
+                "__typename": "User",
+                "id": "42",
+                "firstName": "John",
+                "lastName": "Smith"
+              }
+            }
+          }
+        """.trimIndent(),
+    )
+    Builder()
+        .serverUrl(mockServer.url())
+        .configureCache(
+            fieldPolicies = emptyMap(),
+        )
+        .build()
+        .use { apolloClient ->
+          val networkResult = apolloClient.query(UserByIdQuery("42"))
+              .fetchPolicy(FetchPolicy.NetworkOnly)
+              .execute()
+          assertEquals(
+              Data(
+                  User(
+                      __typename = "User",
+                      id = "42",
+                      firstName = "John",
+                      lastName = "Smith",
+                  ),
+              ),
+              networkResult.data,
+          )
+
+          val cacheResult = apolloClient.query(UserByIdQuery("43"))
+              .fetchPolicy(FetchPolicy.CacheOnly)
+              .execute()
+          assertIs<CacheMissException>(cacheResult.exception)
+          assertEquals(
+              "Object 'QUERY_ROOT' has no field named 'user({\"id\":\"43\"})'",
+              cacheResult.exception!!.message,
+          )
+        }
+  }
+
+  @Test
+  fun wrongKeyArgCacheHit() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueueString(
+        // language=JSON
+        """
+          {
+            "data": {
+              "user": {
+                "__typename": "User",
+                "id": "42",
+                "firstName": "John",
+                "lastName": "Smith"
+              }
+            }
+          }
+        """.trimIndent(),
+    )
+    Builder()
+        .serverUrl(mockServer.url())
+        .configureCache(
+            fieldPolicies = mapOf(
+                "Query" to FieldPolicies(
+                    fieldPolicies = mapOf(
+                        "user" to FieldPolicies.FieldPolicy(
+                            keyArgs = listOf(
+                                "wrongId",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        .build()
+        .use { apolloClient ->
+          val networkResult = apolloClient.query(UserByIdQuery("42"))
+              .fetchPolicy(FetchPolicy.NetworkOnly)
+              .execute()
+          assertEquals(
+              Data(
+                  User(
+                      __typename = "User",
+                      id = "42",
+                      firstName = "John",
+                      lastName = "Smith",
+                  ),
+              ),
+              networkResult.data,
+          )
+
+          val cacheResult = apolloClient.query(UserByIdQuery("42"))
+              .fetchPolicy(FetchPolicy.CacheOnly)
+              .execute()
+          assertEquals(
+              networkResult.data,
+              cacheResult.data,
+          )
+        }
+  }
+
+  @Test
+  fun wrongKeyArgCacheMiss() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueueString(
+        // language=JSON
+        """
+          {
+            "data": {
+              "user": {
+                "__typename": "User",
+                "id": "42",
+                "firstName": "John",
+                "lastName": "Smith"
+              }
+            }
+          }
+        """.trimIndent(),
+    )
+    Builder()
+        .serverUrl(mockServer.url())
+        .configureCache(
+            fieldPolicies = mapOf(
+                "Query" to FieldPolicies(
+                    fieldPolicies = mapOf(
+                        "user" to FieldPolicies.FieldPolicy(
+                            keyArgs = listOf(
+                                "wrongId",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        .build()
+        .use { apolloClient ->
+          val networkResult = apolloClient.query(UserByIdQuery("42"))
+              .fetchPolicy(FetchPolicy.NetworkOnly)
+              .execute()
+          assertEquals(
+              Data(
+                  User(
+                      __typename = "User",
+                      id = "42",
+                      firstName = "John",
+                      lastName = "Smith",
+                  ),
+              ),
+              networkResult.data,
+          )
+
+          val cacheResult = apolloClient.query(UserByIdQuery("43"))
+              .fetchPolicy(FetchPolicy.CacheOnly)
+              .execute()
+          assertEquals(
+              "Object 'QUERY_ROOT' has no field named 'user({\"id\":\"43\"})'",
+              cacheResult.exception!!.message,
+          )
+        }
+  }
+
+}
+
+private fun Builder.configureCache(
+    fieldPolicies: Map<String, FieldPolicies>,
+): Builder = apply {
+  normalizedCache(
+      normalizedCacheFactory = MemoryCacheFactory(),
+      typePolicies = Cache.typePolicies,
+      fieldPolicies = fieldPolicies,
+      connectionTypes = Cache.connectionTypes,
+      embeddedFields = Cache.embeddedFields,
+      maxAges = Cache.maxAges,
+      defaultMaxAge = Duration.INFINITE,
+      keyScope = CacheKey.Scope.TYPE,
+      enableOptimisticUpdates = false,
+      writeToCacheAsynchronously = false,
+  )
+}


### PR DESCRIPTION
When wrong key args are supplied, it could lead to returning a cache key with a null value (e.g. `User:null`), which is confusing. Instead, fallback to the default cache resolver. 