### PR TITLE
Fix refetchPolicy(CacheFirst) not falling through to network on cache miss

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/refetchPolicy.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/refetchPolicy.kt
@@ -31,7 +31,7 @@ fun <T> MutableExecutionOptions<T>.refetchPolicyInterceptor(interceptor: ApolloI
 @Suppress("UNCHECKED_CAST")
 fun <T> MutableExecutionOptions<T>.refetchPolicy(fetchPolicy: FetchPolicy): T {
   // Reset first
-  refetchOnlyIfCached(true)
+  refetchOnlyIfCached(false)
   refetchNoCache(false)
   return when (fetchPolicy) {
     FetchPolicy.NetworkFirst -> {

--- a/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
@@ -359,6 +359,43 @@ class WatcherTest {
     job.cancel()
   }
 
+  /**
+   * A test to test refetching with a CacheFirst refetchPolicy. On a cache miss during refetch,
+   * the watcher should fall through to the network.
+   */
+  @Test
+  fun cacheFirstRefetchPolicy() = runTest(before = { setUp() }) {
+    val channel = Channel<ApolloResponse<EpisodeHeroNameQuery.Data>>(capacity = Channel.UNLIMITED)
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+
+    // Seed the watcher with an initial "R2-D2" response from the network
+    apolloClient.enqueueTestResponse(query, episodeHeroNameData)
+    val job = launch {
+      apolloClient.query(query)
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .refetchPolicy(FetchPolicy.CacheFirst)
+          .watch()
+          .collect {
+            channel.send(it)
+          }
+    }
+    assertEquals("R2-D2", channel.awaitElement().data?.hero?.name)
+
+    // Clear the cache so the next refetch produces a cache miss.
+    // With CacheFirst, the watcher is expected to fall through to the network.
+    apolloClient.enqueueTestResponse(query, episodeHeroNameChangedData)
+    cacheManager.clearAll()
+    cacheManager.publish(CacheManager.ALL_KEYS)
+
+    // Cache miss is emitted first (null data)
+    assertIs<CacheMissException>(channel.awaitElement().exception)
+
+    // The network fall-through brings back "Artoo"
+    assertEquals("Artoo", channel.awaitElement().data?.hero?.name)
+
+    job.cancel()
+  }
+
 
   @Test
   fun nothingReceivedWhenCancelled() = runTest(before = { setUp() }) {


### PR DESCRIPTION
When a watcher is configured with `refetchPolicy(FetchPolicy.CacheFirst)`, it never hits the network on a cache miss during refetch — it silently behaves like `CacheOnly`.

The cause is the "reset first" block in `refetchPolicy()`:

```kotlin
// Reset first
refetchOnlyIfCached(true)  // should be false
refetchNoCache(false)
```

The analogous `fetchPolicy()` function resets to `onlyIfCached(false)`, and each restrictive branch flips the flag back to `true` as needed (`CacheOnly`). The refetch variant resets to `onlyIfCached(true)` instead, and since the `CacheFirst` branch is a no-op (`this as T`), the flag stays `true`. `DefaultFetchPolicyInterceptor` then skips its `chain.proceed(request)` network call because `request.onlyIfCached` is `true`, so the watcher only ever emits the cache response.

This PR flips the reset to `false` to match `fetchPolicy()`. `CacheOnly` still sets it back to `true` explicitly. `NetworkOnly` already flips it off via the mutual-exclusion logic in `refetchNoCache()`. `NetworkFirst` and `CacheAndNetwork` use their own interceptors that do not consult `onlyIfCached`.

### Reproduction

The added `WatcherTest.cacheFirstRefetchPolicy` test pins the expected behavior: with a `CacheFirst` refetch policy, after `cacheManager.clearAll() + publish(ALL_KEYS)`, the watcher emits the `CacheMissException` and then the network response. Without the fix it times out waiting for the network response.