### PR TITLE
Pagination: correctly handle merging empty pages

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/RecordMerger.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/RecordMerger.kt
@@ -164,9 +164,6 @@ private object ConnectionFieldMerger : FieldMerger {
     } else if (existingStartCursor == null && existingEndCursor == null) {
       // Existing is empty
       incoming
-    } else if (incomingStartCursor == null && incomingEndCursor == null) {
-      // Incoming is empty
-      existing
     } else if (incomingBeforeArgument == null && incomingAfterArgument == null) {
       // Incoming is not a pagination query, or a first page query
       // Handle this case by resetting the cache with this page
@@ -195,7 +192,8 @@ private object ConnectionFieldMerger : FieldMerger {
       if (incomingAfterArgument == existingEndCursor) {
         // Append to the end
         mergedStartCursor = existingStartCursor
-        mergedEndCursor = incomingEndCursor
+        // If incoming is empty, don't overwrite the existing end cursor we have
+        mergedEndCursor = incomingEndCursor ?: existingEndCursor
         mergedEdges = if (existingEdges == null || incomingEdges == null) {
           null
         } else {
@@ -210,7 +208,8 @@ private object ConnectionFieldMerger : FieldMerger {
         mergedHasNextPage = incomingHasNextPage
       } else if (incomingBeforeArgument == existingStartCursor) {
         // Prepend to the start
-        mergedStartCursor = incomingStartCursor
+        // If incoming is empty, don't overwrite the existing start cursor we have
+        mergedStartCursor = incomingStartCursor ?: existingStartCursor
         mergedEndCursor = existingEndCursor
         mergedEdges = if (existingEdges == null || incomingEdges == null) {
           null

--- a/tests/pagination/src/commonTest/kotlin/ConnectionPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/ConnectionPaginationTest.kt
@@ -443,4 +443,78 @@ class ConnectionPaginationTest {
     assertChainedCachesAreEqual(cacheManager)
   }
 
+  @Test
+  fun emptyPageMemoryCache() {
+    emptyPageTest(MemoryCacheFactory())
+  }
+
+  @Test
+  fun emptyPageSqlCache() {
+    emptyPageTest(SqlNormalizedCacheFactory())
+  }
+
+  @Test
+  fun emptyPageChainedCache() {
+    emptyPageTest(MemoryCacheFactory().chain(SqlNormalizedCacheFactory()))
+  }
+
+  private fun emptyPageTest(cacheFactory: NormalizedCacheFactory) = runTest {
+    val cacheManager = CacheManager(
+        normalizedCacheFactory = cacheFactory,
+        cacheKeyGenerator = TypePolicyCacheKeyGenerator(Cache.typePolicies),
+        cacheResolver = FieldPolicyCacheResolver(Cache.fieldPolicies),
+        metadataGenerator = ConnectionMetadataGenerator(Cache.connectionTypes),
+        recordMerger = ConnectionRecordMerger,
+        fieldKeyGenerator = ConnectionFieldKeyGenerator(Cache.connectionTypes),
+        embeddedFieldsProvider = DefaultEmbeddedFieldsProvider(Cache.embeddedFields),
+    )
+    cacheManager.clearAll()
+
+    // First page
+    val query1 = UsersQuery(first = Optional.Present(2))
+    val data1 = UsersQuery.Data {
+      users = buildUserConnection {
+        pageInfo = buildPageInfo {
+          startCursor = "xx42"
+          endCursor = "xx43"
+        }
+        edges = listOf(
+            buildUserEdge {
+              cursor = "xx42"
+              node = buildUser {
+                id = "42"
+              }
+            },
+            buildUserEdge {
+              cursor = "xx43"
+              node = buildUser {
+                id = "43"
+              }
+            },
+        )
+      }
+    }
+    cacheManager.writeOperation(query1, data1)
+    var dataFromStore = cacheManager.readOperation(query1).data
+    assertEquals(data1, dataFromStore)
+    assertChainedCachesAreEqual(cacheManager)
+
+    // Page after, empty
+    val query2 = UsersQuery(first = Optional.Present(2), after = Optional.Present("xx43"))
+    val data2 = UsersQuery.Data {
+      users = buildUserConnection {
+        pageInfo = buildPageInfo {
+          startCursor = null
+          endCursor = null
+        }
+        edges = emptyList()
+      }
+    }
+    cacheManager.writeOperation(query2, data2)
+    dataFromStore = cacheManager.readOperation(query1).data
+    val expectedData = data1
+    assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(cacheManager)
+  }
+
 }


### PR DESCRIPTION
With the current behavior, empty pages would basically be ignored, which works to a degree, but we still should correctly merge the PageInfo, and any other custom fields in the connection. This fix addresses this. Thanks @AlexanderGH for reporting!