### PR TITLE
CacheFirstFetchPolicy: go to the network after a cache miss only

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/FetchPolicyInterceptors.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/FetchPolicyInterceptors.kt
@@ -47,7 +47,7 @@ val DefaultFetchPolicyInterceptor = object : ApolloInterceptor {
             cacheResponse.newBuilder().isLast(request.onlyIfCached || cacheResponse.exception == null)
                 .build(),
         )
-        if (cacheResponse.exception == null) {
+        if (cacheResponse.exception !is CacheMissException) {
           return@flow
         }
       }

--- a/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
@@ -7,7 +7,6 @@ import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloGraphQLException
-import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.exception.ApolloNetworkException
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.network.NetworkTransport
@@ -454,13 +453,10 @@ class DeferNormalizedCacheTest {
     )
     assertResponseListEquals(networkExpected, networkActual)
 
-    mockServer.enqueueError(statusCode = 500)
-    // Because of the error we fallback to the network (which also fails)
+    // The error was stored in the cache and is surfaced as an exception
     val exception = apolloClient.query(WithFragmentSpreadsQuery()).execute().exception
     check(exception is ApolloGraphQLException)
-    assertIs<ApolloHttpException>(exception.suppressedExceptions.first())
     assertEquals("GraphQL error: 'Cannot resolve isColor'", exception.message)
-    mockServer.awaitRequest()
   }
 
   @Test

--- a/tests/fetch-policy/build.gradle.kts
+++ b/tests/fetch-policy/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
         implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
+        implementation(libs.turbine)
       }
     }
 

--- a/tests/fetch-policy/build.gradle.kts
+++ b/tests/fetch-policy/build.gradle.kts
@@ -1,0 +1,49 @@
+import com.apollographql.apollo.annotations.ApolloExperimental
+
+plugins {
+  alias(libs.plugins.kotlin.multiplatform)
+  id("com.apollographql.apollo")
+}
+
+kotlin {
+  configureKmp(
+      withJs = setOf(JsAndWasmEnvironment.Node),
+      withWasm = emptySet(),
+      withAndroid = false,
+      withApple = AppleTargets.Host,
+  )
+
+  sourceSets {
+    getByName("commonMain") {
+      dependencies {
+        implementation(libs.apollo.runtime)
+        implementation("com.apollographql.cache:normalized-cache")
+      }
+    }
+
+    getByName("commonTest") {
+      dependencies {
+        implementation("com.apollographql.cache:test-utils")
+        implementation(libs.apollo.mockserver)
+        implementation(libs.kotlin.test)
+      }
+    }
+
+    getByName("jvmTest") {
+      dependencies {
+        implementation(libs.slf4j.nop)
+      }
+    }
+  }
+}
+
+apollo {
+  service("service") {
+    packageName.set("test")
+
+    @OptIn(ApolloExperimental::class)
+    plugin("com.apollographql.cache:normalized-cache-apollo-compiler-plugin") {
+      argument("com.apollographql.cache.packageName", packageName.get())
+    }
+  }
+}

--- a/tests/fetch-policy/src/commonMain/graphql/extra.graphqls
+++ b/tests/fetch-policy/src/commonMain/graphql/extra.graphqls
@@ -1,0 +1,10 @@
+extend schema
+@link(
+  url: "https://specs.apollo.dev/kotlin_labs/v0.3"
+)
+@link(
+  url: "https://specs.apollo.dev/cache/v0.3",
+  import: ["@typePolicy", "@cacheControl", "@cacheControlField"]
+)
+
+extend type User @typePolicy(keyFields: "id")

--- a/tests/fetch-policy/src/commonMain/graphql/operation.graphql
+++ b/tests/fetch-policy/src/commonMain/graphql/operation.graphql
@@ -1,0 +1,7 @@
+query MeQuery {
+  me {
+    id
+    firstName
+    lastName
+  }
+}

--- a/tests/fetch-policy/src/commonMain/graphql/schema.graphqls
+++ b/tests/fetch-policy/src/commonMain/graphql/schema.graphqls
@@ -1,0 +1,10 @@
+type Query {
+  me: User!
+}
+
+type User {
+  id: ID!
+  firstName: String
+  lastName: String
+  email: String
+}

--- a/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -3,8 +3,8 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.cache.normalized.FetchPolicy.CacheFirst
 import com.apollographql.cache.normalized.isFromCache
-import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.refetchPolicy
+import com.apollographql.cache.normalized.testing.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.watch
 import com.apollographql.mockserver.MockServer
@@ -54,7 +54,7 @@ class FetchPolicyTest {
     }
     ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .cache(MemoryCacheFactory(), writeToCacheAsynchronously = true)
+        .cache(SqlNormalizedCacheFactory(), writeToCacheAsynchronously = true)
         .build()
         .use { apolloClient ->
           apolloClient.query(MeQuery())

--- a/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -1,0 +1,68 @@
+package test
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.cache.normalized.FetchPolicy.CacheFirst
+import com.apollographql.cache.normalized.isFromCache
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.refetchPolicy
+import com.apollographql.cache.normalized.testing.runTest
+import com.apollographql.cache.normalized.watch
+import com.apollographql.mockserver.MockServer
+import com.apollographql.mockserver.enqueueString
+import okio.use
+import test.cache.Cache.cache
+import kotlin.test.Test
+
+class FetchPolicyTest {
+  private lateinit var mockServer: MockServer
+
+  private fun setUp() {
+    mockServer = MockServer()
+  }
+
+  private fun tearDown() {
+    mockServer.close()
+  }
+
+  @Test
+  fun refetchPolicyCacheFirstWithWriteToCacheAsync() = runTest(before = { setUp() }, after = { tearDown() }) {
+    repeat(10) {
+      mockServer.enqueueString(
+          // language=JSON
+          """
+        {
+          "errors": [
+            {
+              "message": "Can't compute lastName",
+              "path": [
+                "me",
+                "lastName"
+              ]
+            }
+          ],
+          "data": {
+            "me": {
+              "__typename": "User",
+              "id": "1",
+              "firstName": "John",
+              "lastName": null
+            }
+          }
+        }
+        """.trimIndent(),
+      )
+    }
+    ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .cache(MemoryCacheFactory(), writeToCacheAsynchronously = true)
+        .build()
+        .use { apolloClient ->
+          apolloClient.query(MeQuery())
+              .refetchPolicy(CacheFirst)
+              .watch()
+              .collect { response ->
+                println(response.toString() + " isFromCache=" + response.isFromCache)
+              }
+        }
+  }
+}

--- a/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -1,68 +1,130 @@
 package test
 
+import app.cash.turbine.test
+import app.cash.turbine.withTurbineTimeout
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Error
+import com.apollographql.apollo.exception.ApolloGraphQLException
+import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.cache.normalized.FetchPolicy.CacheFirst
+import com.apollographql.cache.normalized.api.CacheHeaders
+import com.apollographql.cache.normalized.api.NormalizedCache
+import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.api.Record
+import com.apollographql.cache.normalized.api.RecordMerger
 import com.apollographql.cache.normalized.isFromCache
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.refetchPolicy
-import com.apollographql.cache.normalized.testing.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.assertErrorsEquals
 import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.watch
+import com.apollographql.mockserver.MockRequestBase
+import com.apollographql.mockserver.MockResponse
 import com.apollographql.mockserver.MockServer
-import com.apollographql.mockserver.enqueueString
+import com.apollographql.mockserver.MockServerHandler
+import kotlinx.coroutines.delay
 import okio.use
 import test.cache.Cache.cache
+import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class FetchPolicyTest {
-  private lateinit var mockServer: MockServer
-
-  private fun setUp() {
-    mockServer = MockServer()
-  }
-
-  private fun tearDown() {
-    mockServer.close()
-  }
-
   @Test
-  fun refetchPolicyCacheFirstWithWriteToCacheAsync() = runTest(before = { setUp() }, after = { tearDown() }) {
-    repeat(10) {
-      mockServer.enqueueString(
-          // language=JSON
-          """
-        {
-          "errors": [
-            {
-              "message": "Can't compute lastName",
-              "path": [
-                "me",
-                "lastName"
-              ]
-            }
-          ],
-          "data": {
-            "me": {
-              "__typename": "User",
-              "id": "1",
-              "firstName": "John",
-              "lastName": null
-            }
+  fun writeToCacheAsyncWithRefetchPolicyCacheFirstAndServerErrors() = runTest {
+    MockServer.Builder().handler(
+        object : MockServerHandler {
+          override fun handle(request: MockRequestBase): MockResponse {
+            return MockResponse.Builder()
+                .body(
+                    // language=JSON
+                    """
+                    {
+                      "errors": [
+                        {
+                          "message": "Can't compute lastName",
+                          "path": [
+                            "me",
+                            "lastName"
+                          ]
+                        }
+                      ],
+                      "data": {
+                        "me": {
+                          "__typename": "User",
+                          "id": "1",
+                          "firstName": "${Random.nextInt()}",
+                          "lastName": null
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+                .build()
           }
         }
-        """.trimIndent(),
-      )
+    ).build().use { mockServer ->
+      ApolloClient.Builder()
+          .serverUrl(mockServer.url())
+          .cache(AsyncCacheFactory(), writeToCacheAsynchronously = true)
+          .build()
+          .use { apolloClient ->
+            apolloClient.query(MeQuery())
+                .refetchPolicy(CacheFirst)
+                .watch()
+                .test {
+                  // 1. response from the cache (cache miss)
+                  val cacheResponse1 = awaitItem()
+                  assertTrue(cacheResponse1.isFromCache)
+                  assertIs<CacheMissException>(cacheResponse1.exception)
+
+                  // 2. response from the network, with the error
+                  val networkResponse1 = awaitItem()
+                  assertFalse(networkResponse1.isFromCache)
+                  assertErrorsEquals(
+                      listOf(Error.Builder("Can't compute lastName").path(listOf("me", "lastName")).build()),
+                      networkResponse1.errors
+                  )
+
+                  // 3. with writeToCacheAsynchronously, when the network response is written to the cache, the watcher gets notified with the cache response
+                  val cacheResponse2 = awaitItem()
+                  assertTrue(cacheResponse2.isFromCache)
+                  // GraphQL error is surfaced as an exception by default (serverErrorsAsException is true)
+                  assertIs<ApolloGraphQLException>(cacheResponse2.exception)
+
+                  // That wasn't a cache miss: expect no more emissions
+                  withTurbineTimeout(200.milliseconds) {
+                    assertFails { awaitItem() }
+                  }
+
+                  cancelAndIgnoreRemainingEvents()
+                }
+          }
     }
-    ApolloClient.Builder()
-        .serverUrl(mockServer.url())
-        .cache(SqlNormalizedCacheFactory(), writeToCacheAsynchronously = true)
-        .build()
-        .use { apolloClient ->
-          apolloClient.query(MeQuery())
-              .refetchPolicy(CacheFirst)
-              .watch()
-              .collect { response ->
-                println(response.toString() + " isFromCache=" + response.isFromCache)
-              }
-        }
+  }
+}
+
+/**
+ * A cache that simulates slow writes.
+ * This removes flakiness by ensuring that when using `writeToCacheAsynchronously = true`, there is enough time to start observing the
+ * cache, before writing happens.
+ */
+private fun AsyncCacheFactory(): NormalizedCacheFactory = object : NormalizedCacheFactory() {
+  override fun create(): NormalizedCache {
+    val wrapped = MemoryCacheFactory().create()
+    return object : NormalizedCache by wrapped {
+      override suspend fun merge(
+          records: Collection<Record>,
+          cacheHeaders: CacheHeaders,
+          recordMerger: RecordMerger,
+      ): Set<String> {
+        delay(100.milliseconds)
+        return wrapped.merge(records, cacheHeaders, recordMerger)
+      }
+    }
   }
 }


### PR DESCRIPTION
In `DefaultFetchPolicyInterceptor`, the test to decide to go to the network after trying the cache was too broad: any exception, instead of cache miss exceptions. This could cause going to the network when a response _is_ in the cache but contains errors, which in turn could cause an infinite loop when using watchers and `writeToCacheAsynchronously`.