### PR TITLE
Revert changing test to fetch from the network to be any exception

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/FetchPolicy.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/FetchPolicy.kt
@@ -4,9 +4,10 @@ import com.apollographql.apollo.ApolloCall
 
 enum class FetchPolicy {
   /**
-   * Emit the response from the cache first, and if there was a cache miss, emit the response(s) from the network.
+   * Emit the response from the cache first, and if there was an exception on the response (e.g. a cache miss or a cached server error),
+   * emits the response(s) from the network.
    *
-   * This is the default behaviour.
+   * This is the default behavior.
    */
   CacheFirst,
 

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/FetchPolicyInterceptors.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/FetchPolicyInterceptors.kt
@@ -22,7 +22,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.single
 
 /**
- * An interceptor that emits the response from the cache first, and if there was a cache miss, emits the response(s) from the network.
+ * An interceptor that emits the response from the cache first, and if there was an exception on the response (e.g. a cache miss or a cached
+ * server error), emits the response(s) from the network.
  *
  * This is the default cache policy interceptor.
  *
@@ -43,11 +44,8 @@ val DefaultFetchPolicyInterceptor = object : ApolloInterceptor {
                 .fetchFromCache(true)
                 .build(),
         ).single()
-        emit(
-            cacheResponse.newBuilder().isLast(request.onlyIfCached || cacheResponse.exception == null)
-                .build(),
-        )
-        if (cacheResponse.exception !is CacheMissException) {
+        emit(cacheResponse.newBuilder().isLast(request.onlyIfCached || cacheResponse.exception == null).build())
+        if (cacheResponse.exception == null) {
           return@flow
         }
       }

--- a/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloGraphQLException
+import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.exception.ApolloNetworkException
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.network.NetworkTransport
@@ -453,10 +454,13 @@ class DeferNormalizedCacheTest {
     )
     assertResponseListEquals(networkExpected, networkActual)
 
-    // The error was stored in the cache and is surfaced as an exception
+    mockServer.enqueueError(statusCode = 500)
+    // Because of the error we fallback to the network (which also fails)
     val exception = apolloClient.query(WithFragmentSpreadsQuery()).execute().exception
     check(exception is ApolloGraphQLException)
+    assertIs<ApolloHttpException>(exception.suppressedExceptions.first())
     assertEquals("GraphQL error: 'Cannot resolve isColor'", exception.message)
+    mockServer.awaitRequest()
   }
 
   @Test

--- a/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -3,18 +3,23 @@ package test
 import app.cash.turbine.test
 import app.cash.turbine.withTurbineTimeout
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.ApolloRequest
+import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Error
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.exception.ApolloGraphQLException
 import com.apollographql.apollo.exception.CacheMissException
-import com.apollographql.cache.normalized.FetchPolicy.CacheFirst
+import com.apollographql.apollo.interceptor.ApolloInterceptor
+import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.cache.normalized.api.CacheHeaders
 import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.api.RecordMerger
+import com.apollographql.cache.normalized.fetchFromCache
 import com.apollographql.cache.normalized.isFromCache
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
-import com.apollographql.cache.normalized.refetchPolicy
+import com.apollographql.cache.normalized.refetchPolicyInterceptor
 import com.apollographql.cache.normalized.testing.assertErrorsEquals
 import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.watch
@@ -23,6 +28,10 @@ import com.apollographql.mockserver.MockResponse
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.MockServerHandler
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
 import okio.use
 import test.cache.Cache.cache
 import kotlin.random.Random
@@ -74,7 +83,7 @@ class FetchPolicyTest {
           .build()
           .use { apolloClient ->
             apolloClient.query(MeQuery())
-                .refetchPolicy(CacheFirst)
+                .refetchPolicyInterceptor(PartialCacheFirstInterceptor)
                 .watch()
                 .test {
                   // 1. response from the cache (cache miss)
@@ -124,6 +133,30 @@ private fun AsyncCacheFactory(): NormalizedCacheFactory = object : NormalizedCac
       ): Set<String> {
         delay(100.milliseconds)
         return wrapped.merge(records, cacheHeaders, recordMerger)
+      }
+    }
+  }
+}
+
+/**
+ * An interceptor that emits the response from the cache first, and if there was a cache miss on the response, emits the response(s) from
+ * the network.
+ * If there are no exception on the cache response or there is an exception which is not a cache miss (server error), no network request is
+ * made.
+ */
+val PartialCacheFirstInterceptor = object : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    return flow {
+      val cacheResponse = chain.proceed(
+          request = request
+              .newBuilder()
+              .fetchFromCache(true)
+              .build(),
+      ).single()
+      val isCacheMiss = cacheResponse.exception == CacheMissException
+      emit(cacheResponse.newBuilder().isLast(!isCacheMiss).build())
+      if (isCacheMiss) {
+        emitAll(chain.proceed(request = request))
       }
     }
   }


### PR DESCRIPTION
In #351 we changed the test in the `DefaultFetchPolicyInterceptor` to go to the network only after a cache miss. However, this is a behavior change that may surprise users.

By default, partial responses from the cache are not enabled (`serverErrorsAsException(true)` is the default). This means that errors stored in the cache essentially behave as cache misses. This should also be true for the `CacheFirst` policy, in other words: when `serverErrorsAsException` is true, cached network errors should trigger a network request.

Users who need more control can implement a custom `FetchPolicyInterceptor` as shown in the test.