### PR TITLE
Set received date only on incoming record fields when merging

### DIFF
--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
@@ -170,14 +170,15 @@ class SqlNormalizedCache internal constructor(
       recordDatabase.transaction {
         val existingRecords = selectRecords(records.map { it.key }).associateBy { it.key }
         records.flatMap { record ->
+          val record = record.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
           val existingRecord = existingRecords[record.key]
           if (existingRecord == null) {
-            recordDatabase.insertOrUpdateRecord(record.withDates(receivedDate = receivedDate, expirationDate = expirationDate))
+            recordDatabase.insertOrUpdateRecord(record)
             record.fieldKeys()
           } else {
             val (mergedRecord, changedKeys) = recordMerger.merge(RecordMergerContext(existing = existingRecord, incoming = record, cacheHeaders = cacheHeaders))
             if (mergedRecord.isNotEmpty()) {
-              recordDatabase.insertOrUpdateRecord(mergedRecord.withDates(receivedDate = receivedDate, expirationDate = expirationDate))
+              recordDatabase.insertOrUpdateRecord(mergedRecord)
             }
             changedKeys
           }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
@@ -122,17 +122,16 @@ class MemoryCache(
       val existingRecords = loadRecords(records.map { it.key }, cacheHeaders).associateBy { it.key }
       val recordsToInsert = mutableListOf<Record>()
       val changedKeys = records.flatMap { record ->
+        val record = record.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
         val existingRecord = existingRecords[record.key]
         if (existingRecord == null) {
-          val record = record.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
           recordsToInsert.add(record)
           lruCache[record.key] = record
           record.fieldKeys()
         } else {
           val (mergedRecord, changedKeys) = recordMerger.merge(RecordMergerContext(existing = existingRecord, incoming = record, cacheHeaders = cacheHeaders))
-          val mergedRecordWithDates = mergedRecord.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
-          recordsToInsert.add(mergedRecordWithDates)
-          lruCache[record.key] = mergedRecordWithDates
+          recordsToInsert.add(mergedRecord)
+          lruCache[record.key] = mergedRecord
           changedKeys
         }
       }.toSet()

--- a/tests/cache-control/src/commonTest/kotlin/MergeTest.kt
+++ b/tests/cache-control/src/commonTest/kotlin/MergeTest.kt
@@ -1,0 +1,62 @@
+package test
+
+import com.apollographql.cache.normalized.api.ApolloCacheHeaders
+import com.apollographql.cache.normalized.api.CacheHeaders
+import com.apollographql.cache.normalized.api.CacheKey
+import com.apollographql.cache.normalized.api.DefaultRecordMerger
+import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.api.Record
+import com.apollographql.cache.normalized.api.receivedDate
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.testing.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MergeTest {
+  @Test
+  fun mergeDatesMemoryCache() {
+    mergeDates(MemoryCacheFactory())
+  }
+
+  @Test
+  fun mergeDatesSqlCache() {
+    mergeDates(SqlNormalizedCacheFactory())
+  }
+
+  @Test
+  fun mergeDatesChainedCache() {
+    mergeDates(MemoryCacheFactory().chain(SqlNormalizedCacheFactory()))
+  }
+
+  private fun mergeDates(normalizedCacheFactory: NormalizedCacheFactory) = runTest {
+    val normalizedCache = normalizedCacheFactory.create()
+    try {
+      normalizedCache.merge(
+          record = Record(
+              key = CacheKey("Key"),
+              fields = mapOf("field1" to "value1"),
+          ),
+          cacheHeaders = CacheHeaders.Builder().addHeader(ApolloCacheHeaders.RECEIVED_DATE, "1").build(),
+          recordMerger = DefaultRecordMerger
+      )
+      normalizedCache.merge(
+          record = Record(
+              key = CacheKey("Key"),
+              fields = mapOf("field2" to "value2"),
+          ),
+          cacheHeaders = CacheHeaders.Builder().addHeader(ApolloCacheHeaders.RECEIVED_DATE, "2").build(),
+          recordMerger = DefaultRecordMerger
+      )
+      normalizedCache.loadRecord(
+          key = CacheKey("Key"),
+          cacheHeaders = CacheHeaders.NONE,
+      )!!.let { record ->
+        assertEquals(1, record.receivedDate("field1"))
+        assertEquals(2, record.receivedDate("field2"))
+      }
+    } finally {
+      normalizedCache.close()
+    }
+  }
+}


### PR DESCRIPTION
Setting the received date on the merged record will override all of the record's field dates. This PR fixes that by setting the date on the incoming record.