### PR TITLE
Avoid adding key fields that are already selected

### DIFF
--- a/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsDocumentTransform.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsDocumentTransform.kt
@@ -205,7 +205,8 @@ private class AddKeyFieldsExecutableDocumentTransformProcessor(
     val fieldNames = newSelections.filterIsInstance<GQLField>().map { it.responseName() }.toSet()
     val fieldNamesToAdd = (parentTypeKeyFields - fieldNames)
 
-    // Unions and interfaces without key fields: add key fields of all possible types in inline fragments
+    // Unions and interfaces without key fields: add key fields of all possible types in inline fragments (excluding the ones
+    // that are already selected)
     val inlineFragmentsToAdd = if (parentTypeKeyFields.isEmpty()) {
       val parentTypeDefinition = schema.typeDefinition(parentType)
       val possibleTypes = if (parentTypeDefinition is GQLInterfaceTypeDefinition || parentTypeDefinition is GQLUnionTypeDefinition) {

--- a/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsDocumentTransform.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsDocumentTransform.kt
@@ -225,11 +225,11 @@ private class AddKeyFieldsExecutableDocumentTransformProcessor(
             }
             val possibleTypeWithParents =
               (schema.typeDefinition(possibleType) as GQLObjectTypeDefinition).implementsInterfaces + possibleType
-            val alreadySelectedFieldNames = fieldsWithTypeConditions
+            val possibleTypeAlreadySelectedFields = fieldsWithTypeConditions
                 .filter { it.typeCondition in possibleTypeWithParents }
                 .map { it.fieldName }
                 .toSet()
-            val fieldNamesToAddInInlineFragment = possibleTypeKeyFields - fieldNames - alreadySelectedFieldNames
+            val fieldNamesToAddInInlineFragment = possibleTypeKeyFields - fieldNames - possibleTypeAlreadySelectedFields
             if (fieldNamesToAddInInlineFragment.isNotEmpty()) {
               GQLInlineFragment(
                   typeCondition = GQLNamedType(null, possibleType),

--- a/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsDocumentTransform.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsDocumentTransform.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo.ast.GQLFragmentSpread
 import com.apollographql.apollo.ast.GQLInlineFragment
 import com.apollographql.apollo.ast.GQLInterfaceTypeDefinition
 import com.apollographql.apollo.ast.GQLNamedType
+import com.apollographql.apollo.ast.GQLObjectTypeDefinition
 import com.apollographql.apollo.ast.GQLOperationDefinition
 import com.apollographql.apollo.ast.GQLSelection
 import com.apollographql.apollo.ast.GQLUnionTypeDefinition
@@ -31,35 +32,77 @@ internal object AddKeyFieldsExecutableDocumentTransform : ExecutableDocumentTran
       document: GQLDocument,
       extraFragmentDefinitions: List<GQLFragmentDefinition>,
   ): GQLDocument {
-    val keyFields = schema.getTypePolicies().mapValues { it.value.keyFields }
+    return AddKeyFieldsExecutableDocumentTransformProcessor(
+        schema = schema,
+        document = document,
+        extraFragmentDefinitions = extraFragmentDefinitions,
+    ).transform()
+  }
+}
+
+private class AddKeyFieldsExecutableDocumentTransformProcessor(
+    private val schema: Schema,
+    private val document: GQLDocument,
+    private val extraFragmentDefinitions: List<GQLFragmentDefinition>,
+) {
+  private val keyFields = schema.getTypePolicies().mapValues { it.value.keyFields }
+
+  private val fieldsWithTypeConditionsFragmentCache: MutableMap<String, Set<FieldWithTypeCondition>> = mutableMapOf()
+
+  fun transform(): GQLDocument {
     return document.copy(
         definitions = document.definitions.map {
           when (it) {
-            is GQLFragmentDefinition -> it.withRequiredFields(schema, keyFields)
-            is GQLOperationDefinition -> it.withRequiredFields(schema, keyFields)
+            is GQLFragmentDefinition -> it.withRequiredFields()
+            is GQLOperationDefinition -> it.withRequiredFields()
             else -> it
           }
         }
     )
   }
 
-  private fun GQLOperationDefinition.withRequiredFields(schema: Schema, keyFields: Map<String, List<String>>): GQLOperationDefinition {
+  private data class FieldWithTypeCondition(
+      val fieldName: String,
+      val typeCondition: String,
+  )
+
+  private fun GQLFragmentSpread.fieldsWithTypeConditions(): Set<FieldWithTypeCondition> {
+    return fieldsWithTypeConditionsFragmentCache.getOrPut(name) {
+      val fragmentDefinition = (document.definitions.filterIsInstance<GQLFragmentDefinition>() + extraFragmentDefinitions)
+          .firstOrNull { it.name == name }
+          ?: return emptySet()
+      fragmentDefinition.selections.fieldsWithTypeConditions(typeCondition = fragmentDefinition.typeCondition.name)
+    }
+  }
+
+  private fun List<GQLSelection>.fieldsWithTypeConditions(typeCondition: String): Set<FieldWithTypeCondition> = flatMap { selection ->
+    when (selection) {
+      is GQLInlineFragment -> selection.selections.fieldsWithTypeConditions(typeCondition = selection.typeCondition?.name ?: typeCondition)
+
+      is GQLFragmentSpread -> selection.fieldsWithTypeConditions()
+
+      is GQLField -> listOf(
+          FieldWithTypeCondition(
+              fieldName = selection.name,
+              typeCondition = typeCondition
+          )
+      )
+    }
+  }.toSet()
+
+  private fun GQLOperationDefinition.withRequiredFields(): GQLOperationDefinition {
     val parentType = rootTypeDefinition(schema)!!.name
     return copy(
         selections = selections.withRequiredFields(
-            schema = schema,
-            keyFields = keyFields,
             parentType = parentType,
             isRoot = false,
         )
     )
   }
 
-  private fun GQLFragmentDefinition.withRequiredFields(schema: Schema, keyFields: Map<String, List<String>>): GQLFragmentDefinition {
+  private fun GQLFragmentDefinition.withRequiredFields(): GQLFragmentDefinition {
     return copy(
         selections = selections.withRequiredFields(
-            schema = schema,
-            keyFields = keyFields,
             parentType = typeCondition.name,
             isRoot = true,
         ),
@@ -72,8 +115,6 @@ internal object AddKeyFieldsExecutableDocumentTransform : ExecutableDocumentTran
    */
   @OptIn(ApolloInternal::class)
   private fun List<GQLSelection>.withRequiredFields(
-      schema: Schema,
-      keyFields: Map<String, List<String>>,
       parentType: String,
       isRoot: Boolean,
   ): List<GQLSelection> {
@@ -85,8 +126,6 @@ internal object AddKeyFieldsExecutableDocumentTransform : ExecutableDocumentTran
         is GQLInlineFragment -> {
           it.copy(
               selections = it.selections.withRequiredFields(
-                  schema = schema,
-                  keyFields = keyFields,
                   parentType = it.typeCondition?.name ?: parentType,
                   isRoot = false,
               )
@@ -94,11 +133,7 @@ internal object AddKeyFieldsExecutableDocumentTransform : ExecutableDocumentTran
         }
 
         is GQLFragmentSpread -> it
-        is GQLField -> it.withRequiredFields(
-            schema = schema,
-            keyFields = keyFields,
-            parentType = parentType
-        )
+        is GQLField -> it.withRequiredFields(parentType = parentType)
       }
     }
 
@@ -129,10 +164,23 @@ internal object AddKeyFieldsExecutableDocumentTransform : ExecutableDocumentTran
       } else {
         emptySet()
       }
+      var fieldsWithTypeConditions: Set<FieldWithTypeCondition>? = null
       possibleTypes
           .associateWith { possibleType -> keyFields[possibleType] ?: emptyList() }
           .mapNotNull { (possibleType, possibleTypeKeyFields) ->
-            val fieldNamesToAddInInlineFragment = possibleTypeKeyFields - fieldNames
+            if (possibleTypeKeyFields.isEmpty()) {
+              return@mapNotNull null
+            }
+            if (fieldsWithTypeConditions == null) {
+              fieldsWithTypeConditions = fieldsWithTypeConditions(parentType)
+            }
+            val possibleTypeWithParents =
+              (schema.typeDefinition(possibleType) as GQLObjectTypeDefinition).implementsInterfaces + possibleType
+            val alreadySelectedFieldNames = fieldsWithTypeConditions
+                .filter { it.typeCondition in possibleTypeWithParents }
+                .map { it.fieldName }
+                .toSet()
+            val fieldNamesToAddInInlineFragment = possibleTypeKeyFields - fieldNames - alreadySelectedFieldNames
             if (fieldNamesToAddInInlineFragment.isNotEmpty()) {
               GQLInlineFragment(
                   typeCondition = GQLNamedType(null, possibleType),
@@ -154,15 +202,9 @@ internal object AddKeyFieldsExecutableDocumentTransform : ExecutableDocumentTran
     return listOf(buildField("__typename")) + selectionsWithAdditions.filter { (it as? GQLField)?.name != "__typename" }
   }
 
-  private fun GQLField.withRequiredFields(
-      schema: Schema,
-      keyFields: Map<String, List<String>>,
-      parentType: String,
-  ): GQLField {
+  private fun GQLField.withRequiredFields(parentType: String): GQLField {
     val typeDefinition = definitionFromScope(schema, parentType) ?: return this
     val newSelectionSet = selections.withRequiredFields(
-        schema = schema,
-        keyFields = keyFields,
         parentType = typeDefinition.type.rawType().name,
         isRoot = true,
     )

--- a/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsDocumentTransform.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/main/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsDocumentTransform.kt
@@ -4,10 +4,12 @@ package com.apollographql.cache.apollocompilerplugin.internal
 
 import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.annotations.ApolloInternal
+import com.apollographql.apollo.ast.GQLBooleanValue
 import com.apollographql.apollo.ast.GQLDocument
 import com.apollographql.apollo.ast.GQLField
 import com.apollographql.apollo.ast.GQLFragmentDefinition
 import com.apollographql.apollo.ast.GQLFragmentSpread
+import com.apollographql.apollo.ast.GQLHasDirectives
 import com.apollographql.apollo.ast.GQLInlineFragment
 import com.apollographql.apollo.ast.GQLInterfaceTypeDefinition
 import com.apollographql.apollo.ast.GQLNamedType
@@ -66,29 +68,76 @@ private class AddKeyFieldsExecutableDocumentTransformProcessor(
       val typeCondition: String,
   )
 
+  /**
+   * Get field names in the selections, associated with their type condition.
+   * For instance if [typeCondition] is `ParentType`, given:
+   * ```graphql
+   * a
+   * b @skip(if: true)
+   * ... on SomeType {
+   *   x
+   *   z
+   * }
+   * ```
+   * returns:
+   * - a: ParentType
+   * - x: SomeType
+   * - z: SomeType
+   */
+  private fun List<GQLSelection>.fieldsWithTypeConditions(typeCondition: String): Set<FieldWithTypeCondition> = flatMap { selection ->
+    when (selection) {
+      is GQLInlineFragment -> if (selection.shouldIgnore()) {
+        emptyList()
+      } else {
+        selection.selections.fieldsWithTypeConditions(selection.typeCondition?.name ?: typeCondition)
+      }
+
+      is GQLFragmentSpread -> if (selection.shouldIgnore()) {
+        emptyList()
+      } else {
+        selection.fieldsWithTypeConditions()
+      }
+
+      is GQLField -> if (selection.shouldIgnore()) {
+        emptyList()
+      } else {
+        listOf(
+            FieldWithTypeCondition(
+                fieldName = selection.name,
+                typeCondition = typeCondition
+            )
+        )
+      }
+    }
+  }.toSet()
+
   private fun GQLFragmentSpread.fieldsWithTypeConditions(): Set<FieldWithTypeCondition> {
     return fieldsWithTypeConditionsFragmentCache.getOrPut(name) {
       val fragmentDefinition = (document.definitions.filterIsInstance<GQLFragmentDefinition>() + extraFragmentDefinitions)
           .firstOrNull { it.name == name }
-          ?: return emptySet()
-      fragmentDefinition.selections.fieldsWithTypeConditions(typeCondition = fragmentDefinition.typeCondition.name)
+          ?: return@getOrPut emptySet()
+      fragmentDefinition.selections.fieldsWithTypeConditions(fragmentDefinition.typeCondition.name)
     }
   }
 
-  private fun List<GQLSelection>.fieldsWithTypeConditions(typeCondition: String): Set<FieldWithTypeCondition> = flatMap { selection ->
-    when (selection) {
-      is GQLInlineFragment -> selection.selections.fieldsWithTypeConditions(typeCondition = selection.typeCondition?.name ?: typeCondition)
-
-      is GQLFragmentSpread -> selection.fieldsWithTypeConditions()
-
-      is GQLField -> listOf(
-          FieldWithTypeCondition(
-              fieldName = selection.name,
-              typeCondition = typeCondition
-          )
-      )
+  /**
+   * Ignore when:
+   * - @skip(if: true)
+   * - @skip(if: $someVariable) (because we can't know)
+   * - @include(if: false)
+   * - @include(if: $someVariable) (because we can't know)
+   */
+  private fun GQLHasDirectives.shouldIgnore(): Boolean {
+    return directives.any { directive ->
+      directive.name == "skip" && run {
+        val value = directive.arguments.firstOrNull { it.name == "if" }?.value
+        value !is GQLBooleanValue || value.value
+      } || directive.name == "include" && run {
+        val value = directive.arguments.firstOrNull { it.name == "if" }?.value
+        value !is GQLBooleanValue || !value.value
+      }
     }
-  }.toSet()
+  }
 
   private fun GQLOperationDefinition.withRequiredFields(): GQLOperationDefinition {
     val parentType = rootTypeDefinition(schema)!!.name

--- a/normalized-cache-apollo-compiler-plugin/src/test/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsExecutableDocumentTransformTest.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/test/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsExecutableDocumentTransformTest.kt
@@ -175,10 +175,8 @@ class AddKeyFieldsExecutableDocumentTransformTest {
     checkTransform(schemaText, operationText, expected)
   }
 
-  @Test
-  fun keyFieldsOnUnionMembersDontOverselect() {
-    // language=GraphQL
-    val schemaText = """
+  // language=GraphQL
+  private val dontOverSelectSchemaText = """
       type Query {
         user: User
       }
@@ -213,6 +211,8 @@ class AddKeyFieldsExecutableDocumentTransformTest {
       }
     """.trimIndent()
 
+  @Test
+  fun keyFieldsOnUnionMembersDontOverSelect() {
     // language=GraphQL
     val operationText1 = """
       query GetUser {
@@ -255,7 +255,7 @@ class AddKeyFieldsExecutableDocumentTransformTest {
         id
       }
     """.trimIndent()
-    checkTransform(schemaText, operationText1, expected1)
+    checkTransform(dontOverSelectSchemaText, operationText1, expected1)
 
     // language=GraphQL
     val operationText2 = """
@@ -294,7 +294,7 @@ class AddKeyFieldsExecutableDocumentTransformTest {
         }
       }
     """.trimIndent()
-    checkTransform(schemaText, operationText2, expected2)
+    checkTransform(dontOverSelectSchemaText, operationText2, expected2)
 
     // language=GraphQL
     val operationText3 = """
@@ -348,7 +348,859 @@ class AddKeyFieldsExecutableDocumentTransformTest {
         id
       }
     """.trimIndent()
-    checkTransform(schemaText, operationText3, expected3)
+    checkTransform(dontOverSelectSchemaText, operationText3, expected3)
+  }
+
+  @Test
+  fun keyFieldsOnUnionMembersDontOverSelectSkipFragmentSpread() {
+    // language=GraphQL
+    val operationTextSkipFalse = """
+      query GetUser {
+        user {
+          ...NodeIdFragment @skip(if: false)
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipFalse = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment @skip(if: false)
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipFalse, expectedSkipFalse)
+
+    // language=GraphQL
+    val operationTextSkipTrue = """
+      query GetUser {
+        user {
+          ...NodeIdFragment @skip(if: true)
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipTrue = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment @skip(if: true)
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipTrue, expectedSkipTrue)
+
+    // language=GraphQL
+    val operationTextSkipVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          ...NodeIdFragment @skip(if: $variable)
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          __typename
+          ...NodeIdFragment @skip(if: $variable)
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipVariable, expectedSkipVariable)
+  }
+
+  @Test
+  fun keyFieldsOnUnionMembersDontOverSelectSkipInlineFragment() {
+    // language=GraphQL
+    val operationTextSkipFalse = """
+      query GetUser {
+        user {
+          ... on Node @skip(if: false) {
+            id
+          }
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipFalse = """
+      query GetUser {
+        user {
+          __typename
+          ... on Node @skip(if: false) {
+            id
+          }
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipFalse, expectedSkipFalse)
+
+    // language=GraphQL
+    val operationTextSkipTrue = """
+      query GetUser {
+        user {
+          ... on Node @skip(if: true) {
+            id
+          }
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipTrue = """
+      query GetUser {
+        user {
+          __typename
+          ... on Node @skip(if: true) {
+            id
+          }
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipTrue, expectedSkipTrue)
+
+    // language=GraphQL
+    val operationTextSkipVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          ... on Node @skip(if: $variable) {
+            id
+          }
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          __typename
+          ... on Node @skip(if: $variable) {
+            id
+          }
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipVariable, expectedSkipVariable)
+  }
+
+  @Test
+  fun keyFieldsOnUnionMembersDontOverSelectSkipField() {
+    // language=GraphQL
+    val operationTextSkipFalse = """
+      query GetUser {
+        user {
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id @skip(if: false)
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipFalse = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id @skip(if: false)
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipFalse, expectedSkipFalse)
+
+    // language=GraphQL
+    val operationTextSkipTrue = """
+      query GetUser {
+        user {
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id @skip(if: true)
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipTrue = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id @skip(if: true)
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipTrue, expectedSkipTrue)
+
+    // language=GraphQL
+    val operationTextSkipVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id @skip(if: $variable)
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedSkipVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          __typename
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id @skip(if: $variable)
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextSkipVariable, expectedSkipVariable)
+  }
+
+  @Test
+  fun keyFieldsOnUnionMembersDontOverSelectIncludeFragmentSpread() {
+    // language=GraphQL
+    val operationTextIncludeTrue = """
+      query GetUser {
+        user {
+          ...NodeIdFragment @include(if: true)
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeTrue = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment @include(if: true)
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeTrue, expectedIncludeTrue)
+
+    // language=GraphQL
+    val operationTextIncludeFalse = """
+      query GetUser {
+        user {
+          ...NodeIdFragment @include(if: false)
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeFalse = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment @include(if: false)
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeFalse, expectedIncludeFalse)
+
+    // language=GraphQL
+    val operationTextIncludeVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          ...NodeIdFragment @include(if: $variable)
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          __typename
+          ...NodeIdFragment @include(if: $variable)
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeVariable, expectedIncludeVariable)
+  }
+
+  @Test
+  fun keyFieldsOnUnionMembersDontOverSelectIncludeInlineFragment() {
+    // language=GraphQL
+    val operationTextIncludeTrue = """
+      query GetUser {
+        user {
+          ... on Node @include(if: true) {
+            id
+          } 
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeTrue = """
+      query GetUser {
+        user {
+          __typename
+          ... on Node @include(if: true) {
+            id
+          }
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeTrue, expectedIncludeTrue)
+
+    // language=GraphQL
+    val operationTextIncludeFalse = """
+      query GetUser {
+        user {
+          ... on Node @include(if: false) {
+            id
+          }
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeFalse = """
+      query GetUser {
+        user {
+          __typename
+          ... on Node @include(if: false) {
+            id
+          }
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeFalse, expectedIncludeFalse)
+
+    // language=GraphQL
+    val operationTextIncludeVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          ... on Node @include(if: $variable) {
+            id
+          }
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          __typename
+          ... on Node @include(if: $variable) {
+            id
+          }
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeVariable, expectedIncludeVariable)
+  }
+
+  @Test
+  fun keyFieldsOnUnionMembersDontOverSelectIncludeField() {
+    // language=GraphQL
+    val operationTextIncludeTrue = """
+      query GetUser {
+        user {
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id @include(if: true)
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeTrue = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id @include(if: true)
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeTrue, expectedIncludeTrue)
+
+    // language=GraphQL
+    val operationTextIncludeFalse = """
+      query GetUser {
+        user {
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id @include(if: false)
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeFalse = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id @include(if: false)
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeFalse, expectedIncludeFalse)
+
+    // language=GraphQL
+    val operationTextIncludeVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id @include(if: $variable)
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expectedIncludeVariable = $$"""
+      query GetUser($variable: Boolean!) {
+        user {
+          __typename
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Person {
+            id
+          }
+          ... on Robot {
+            id
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id @include(if: $variable)
+      }
+    """.trimIndent()
+    checkTransform(dontOverSelectSchemaText, operationTextIncludeVariable, expectedIncludeVariable)
   }
 
   @Test
@@ -520,9 +1372,7 @@ class AddKeyFieldsExecutableDocumentTransformTest {
 
     checkTransform(schemaText, operationText, expected)
   }
-
 }
-
 
 private fun checkTransform(schemaText: String, operationText: String, expected: String) {
   val schema = schemaText

--- a/normalized-cache-apollo-compiler-plugin/src/test/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsExecutableDocumentTransformTest.kt
+++ b/normalized-cache-apollo-compiler-plugin/src/test/kotlin/com/apollographql/cache/apollocompilerplugin/internal/AddKeyFieldsExecutableDocumentTransformTest.kt
@@ -176,6 +176,182 @@ class AddKeyFieldsExecutableDocumentTransformTest {
   }
 
   @Test
+  fun keyFieldsOnUnionMembersDontOverselect() {
+    // language=GraphQL
+    val schemaText = """
+      type Query {
+        user: User
+      }
+            
+      interface Node @typePolicy(keyFields: "id") {
+        id: ID!
+      }
+            
+      union User = Person | Robot | Company
+      
+      type Person implements Node {
+        id: ID!
+        name: String!
+        friends: [Person!]!
+      }
+      
+      interface NodeWithDescription implements Node {
+        id: ID!
+        description: String!
+      }
+      
+      type Robot implements NodeWithDescription & Node {
+        id: ID!
+        name: String!
+        model: String!
+        description: String!
+      }
+      
+      type Company @typePolicy(keyFields: "id") {
+        name: String!
+        id: ID!
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val operationText1 = """
+      query GetUser {
+        user {
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expected1 = """
+      query GetUser {
+        user {
+          __typename
+          ...NodeIdFragment
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id
+      }
+    """.trimIndent()
+    checkTransform(schemaText, operationText1, expected1)
+
+    // language=GraphQL
+    val operationText2 = """
+      query GetUser {
+        user {
+          ... on Node {
+            id
+          }
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expected2 = """
+      query GetUser {
+        user {
+          __typename
+          ... on Node {
+            id
+          }
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+    """.trimIndent()
+    checkTransform(schemaText, operationText2, expected2)
+
+    // language=GraphQL
+    val operationText3 = """
+      query GetUser {
+        user {
+          ... on Node {
+            ...NodeIdFragment
+            ... on Node {
+              id
+            }
+          }
+          ... on Person {
+            friends {
+              name
+            }
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        id
+      }
+    """.trimIndent()
+
+    // language=GraphQL
+    val expected3 = """
+      query GetUser {
+        user {
+          __typename
+          ... on Node {
+            ...NodeIdFragment
+            ... on Node {
+              id
+            }
+          }
+          ... on Person {
+            friends {
+              __typename
+              name
+              id
+            }
+          }
+          ... on Company {
+            id
+          }
+        }
+      }
+      
+      fragment NodeIdFragment on Node {
+        __typename
+        id
+      }
+    """.trimIndent()
+    checkTransform(schemaText, operationText3, expected3)
+  }
+
+  @Test
   fun keyFieldsOnInterfacePossibleTypes() {
     // language=GraphQL
     val schemaText = """


### PR DESCRIPTION
<!-- GRAPHOS-317 -->

Schema:
```graphql
type Query {
  user: User
}
      
interface Node @typePolicy(keyFields: "id") {
  id: ID!
}
      
union User = Person | Robot

type Person implements Node {
  id: ID!
}

type Robot implements Node {
  id: ID!
}
```

Operation:
```graphql
query GetUser {
  user {
    ...on Node { id }
  }
}
```

### Before
```graphql
query GetUser {
  user {
    __typename
    ...on Node { id }

    # Add key fields for each User possible type
    ...on Person { 
      id
    }
    ...on Robot { 
      id
    }
  }
}
```

### After
```graphql
query GetUser {
  user {
    __typename
    ...on Node { id }

    # Don't add key fields that are already in the selection set
  }
}
```

Limitation: if it can't be determined whether a field is skipped at compile time (`@skip`/`@include` with a variable), it's considered skipped - over-selection can't be avoided in that case.