### PR TITLE
Add in KeyArgumentsCacheResolver default resolver as parameter

### DIFF
--- a/normalized-cache/api/normalized-cache.api
+++ b/normalized-cache/api/normalized-cache.api
@@ -571,6 +571,7 @@ public final class com/apollographql/cache/normalized/api/IdCacheKeyGenerator : 
 
 public final class com/apollographql/cache/normalized/api/KeyArgumentsCacheResolver : com/apollographql/cache/normalized/api/CacheResolver {
 	public fun <init> (Lcom/apollographql/cache/normalized/api/KeyArgumentsProvider;Lcom/apollographql/cache/normalized/api/CacheKey$Scope;)V
+	public fun <init> (Lcom/apollographql/cache/normalized/api/KeyArgumentsProvider;Lcom/apollographql/cache/normalized/api/CacheKey$Scope;Lcom/apollographql/cache/normalized/api/CacheResolver;)V
 	public fun resolveField (Lcom/apollographql/cache/normalized/api/ResolverContext;)Ljava/lang/Object;
 }
 

--- a/normalized-cache/api/normalized-cache.klib.api
+++ b/normalized-cache/api/normalized-cache.klib.api
@@ -302,6 +302,7 @@ final class com.apollographql.cache.normalized.api/IdCacheKeyGenerator : com.apo
 
 final class com.apollographql.cache.normalized.api/KeyArgumentsCacheResolver : com.apollographql.cache.normalized.api/CacheResolver { // com.apollographql.cache.normalized.api/KeyArgumentsCacheResolver|null[0]
     constructor <init>(com.apollographql.cache.normalized.api/KeyArgumentsProvider, com.apollographql.cache.normalized.api/CacheKey.Scope) // com.apollographql.cache.normalized.api/KeyArgumentsCacheResolver.<init>|<init>(com.apollographql.cache.normalized.api.KeyArgumentsProvider;com.apollographql.cache.normalized.api.CacheKey.Scope){}[0]
+    constructor <init>(com.apollographql.cache.normalized.api/KeyArgumentsProvider, com.apollographql.cache.normalized.api/CacheKey.Scope, com.apollographql.cache.normalized.api/CacheResolver) // com.apollographql.cache.normalized.api/KeyArgumentsCacheResolver.<init>|<init>(com.apollographql.cache.normalized.api.KeyArgumentsProvider;com.apollographql.cache.normalized.api.CacheKey.Scope;com.apollographql.cache.normalized.api.CacheResolver){}[0]
 
     final fun resolveField(com.apollographql.cache.normalized.api/ResolverContext): kotlin/Any? // com.apollographql.cache.normalized.api/KeyArgumentsCacheResolver.resolveField|resolveField(com.apollographql.cache.normalized.api.ResolverContext){}[0]
 }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
@@ -353,12 +353,12 @@ interface KeyArgumentsProvider {
  * @param keyArgumentsProvider provides the key arguments for a given field
  * @param keyScope the scope of the computed cache keys. Use [CacheKey.Scope.TYPE] to namespace the keys by the schema type name, or
  * [CacheKey.Scope.SERVICE] if the ids are unique across the whole service.
- * @param defaultCacheResolver the default cache resolver that resolve missing key args fields.
+ * @param delegateResolver the default cache resolver that resolve missing key args fields.
  */
 class KeyArgumentsCacheResolver(
     private val keyArgumentsProvider: KeyArgumentsProvider,
     private val keyScope: CacheKey.Scope,
-    private val defaultCacheResolver: CacheResolver = DefaultCacheResolver,
+    private val delegateResolver: CacheResolver = DefaultCacheResolver,
 ) : CacheResolver {
   override fun resolveField(context: ResolverContext): Any? {
     val fieldKey = context.getFieldKey()
@@ -366,13 +366,13 @@ class KeyArgumentsCacheResolver(
       return context.parent[fieldKey]
     }
     val keyArgs = keyArgumentsProvider.getKeyArguments(context.parentType, context.field)
-        .ifEmpty { return defaultCacheResolver.resolveField(context) }
+        .ifEmpty { return delegateResolver.resolveField(context) }
     val keyArgsWithValues = context.field.argumentValues(context.variables) { it.definition.name in keyArgs }
     // Keep the same order as defined in the field policy
     val keyArgsValues = keyArgs.map {
       if (!keyArgsWithValues.containsKey(it)) {
         // Missing key arg value
-        return defaultCacheResolver.resolveField(context)
+        return delegateResolver.resolveField(context)
       }
       keyArgsWithValues[it]
     }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
@@ -353,10 +353,12 @@ interface KeyArgumentsProvider {
  * @param keyArgumentsProvider provides the key arguments for a given field
  * @param keyScope the scope of the computed cache keys. Use [CacheKey.Scope.TYPE] to namespace the keys by the schema type name, or
  * [CacheKey.Scope.SERVICE] if the ids are unique across the whole service.
+ * @param defaultCacheResolver the default cache resolver that resolve missing key args fields.
  */
 class KeyArgumentsCacheResolver(
     private val keyArgumentsProvider: KeyArgumentsProvider,
     private val keyScope: CacheKey.Scope,
+    private val defaultCacheResolver: CacheResolver = DefaultCacheResolver,
 ) : CacheResolver {
   override fun resolveField(context: ResolverContext): Any? {
     val fieldKey = context.getFieldKey()
@@ -364,13 +366,13 @@ class KeyArgumentsCacheResolver(
       return context.parent[fieldKey]
     }
     val keyArgs = keyArgumentsProvider.getKeyArguments(context.parentType, context.field)
-        .ifEmpty { return DefaultCacheResolver.resolveField(context) }
+        .ifEmpty { return defaultCacheResolver.resolveField(context) }
     val keyArgsWithValues = context.field.argumentValues(context.variables) { it.definition.name in keyArgs }
     // Keep the same order as defined in the field policy
     val keyArgsValues = keyArgs.map {
       if (!keyArgsWithValues.containsKey(it)) {
         // Missing key arg value
-        return DefaultCacheResolver.resolveField(context)
+        return defaultCacheResolver.resolveField(context)
       }
       keyArgsWithValues[it]
     }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
@@ -358,8 +358,17 @@ interface KeyArgumentsProvider {
 class KeyArgumentsCacheResolver(
     private val keyArgumentsProvider: KeyArgumentsProvider,
     private val keyScope: CacheKey.Scope,
-    private val delegateResolver: CacheResolver = DefaultCacheResolver,
+    private val delegateResolver: CacheResolver,
 ) : CacheResolver {
+  constructor(
+      keyArgumentsProvider: KeyArgumentsProvider,
+      keyScope: CacheKey.Scope,
+  ) : this(
+      keyArgumentsProvider = keyArgumentsProvider,
+      keyScope = keyScope,
+      delegateResolver = DefaultCacheResolver
+  )
+
   override fun resolveField(context: ResolverContext): Any? {
     val fieldKey = context.getFieldKey()
     if (context.parent.containsKey(fieldKey)) {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
@@ -288,8 +288,7 @@ class CacheControlCacheResolver(
         if (staleDuration >= 0) isStale = true
       }
 
-      val valueExistsInCache = context.parent.containsKey(context.getFieldKey())
-      if (receivedDate == null && expirationDate == null && valueExistsInCache) {
+      if (receivedDate == null && expirationDate == null) {
         // We can't determine the field's staleness: consider it stale
         throw CacheMissException(
             key = context.parentKey.keyToString(),

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
@@ -288,7 +288,8 @@ class CacheControlCacheResolver(
         if (staleDuration >= 0) isStale = true
       }
 
-      if (receivedDate == null && expirationDate == null) {
+      val valueExistsInCache = context.parent.containsKey(context.getFieldKey())
+      if (receivedDate == null && expirationDate == null && valueExistsInCache) {
         // We can't determine the field's staleness: consider it stale
         throw CacheMissException(
             key = context.parentKey.keyToString(),


### PR DESCRIPTION
To exclude some cacheMisses when adding new fields to a query/fragment, we would need to override the default cache resolver in the `KeyArgumentsCacheResolver`.