### PR TITLE
Update the apollo cache namespace

### DIFF
--- a/normalized-cache-sqlite/build.gradle.kts
+++ b/normalized-cache-sqlite/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
 }
 
 android {
-  namespace = "com.apollographql.apollo.cache.normalized.sql"
+  namespace = "com.apollographql.cache.normalized.sql"
   compileSdk = 34
 
   defaultConfig {


### PR DESCRIPTION
In the new AGP 9 version, having both legacy and new cache cause a manifest merge issue because duplicate namespaces cannot exist anymore.

Here is the issue : 
> Namespace 'com.apollographql.apollo.cache.normalized.sql' is used in multiple modules and/or libraries:
com.apollographql.cache:normalized-cache-sqlite-android-debug:1.0.1,
com.apollographql.apollo:apollo-normalized-cache-sqlite-android-debug:4.4.2.

As the new cache have the package name `com.apollographql.cache`, I find it acceptable to update the namespace so it is aligned with the module's package (and fix an issue with the AGP 9 usage 😄). 