### PR TITLE
Add CacheMissException when building CacheInfo

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
@@ -167,6 +167,7 @@ internal class DefaultCacheManager(
                     // Consider cached server errors as cache hits
                     .cacheHit(e !is CacheMissException)
                     .stale(e is CacheMissException && e.stale)
+                    .cacheMissException(e as? CacheMissException)
                     .build(),
             )
             .build()

--- a/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -16,6 +16,7 @@ import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.api.RecordMerger
+import com.apollographql.cache.normalized.cacheInfo
 import com.apollographql.cache.normalized.fetchFromCache
 import com.apollographql.cache.normalized.isFromCache
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
@@ -39,6 +40,8 @@ import kotlin.test.Test
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -90,6 +93,7 @@ class FetchPolicyTest {
                   val cacheResponse1 = awaitItem()
                   assertTrue(cacheResponse1.isFromCache)
                   assertIs<CacheMissException>(cacheResponse1.exception)
+                  assertNotNull(cacheResponse1.cacheInfo?.cacheMissException)
 
                   // 2. response from the network, with the error
                   val networkResponse1 = awaitItem()
@@ -104,6 +108,7 @@ class FetchPolicyTest {
                   assertTrue(cacheResponse2.isFromCache)
                   // GraphQL error is surfaced as an exception by default (serverErrorsAsException is true)
                   assertIs<ApolloGraphQLException>(cacheResponse2.exception)
+                  assertNull(cacheResponse2.cacheInfo?.cacheMissException)
 
                   // That wasn't a cache miss: expect no more emissions
                   withTurbineTimeout(200.milliseconds) {

--- a/tests/normalized-cache/src/commonTest/kotlin/FetchPolicyTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/FetchPolicyTest.kt
@@ -24,6 +24,7 @@ import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.DefaultCacheKeyGenerator
 import com.apollographql.cache.normalized.api.DefaultCacheResolver
+import com.apollographql.cache.normalized.cacheInfo
 import com.apollographql.cache.normalized.cacheManager
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.isFromCache
@@ -407,6 +408,7 @@ class FetchPolicyTest {
     assertEquals(2, responses.size)
     assertNull(responses[0].data)
     assertIs<CacheMissException>(responses[0].exception)
+    assertNotNull(responses[0].cacheInfo?.cacheMissException)
     assertNotNull(responses[1].data)
     assertFalse(responses[1].isFromCache)
     assertEquals("R2-D2", responses[1].data?.hero?.name)


### PR DESCRIPTION
When a cache miss exception happens, the constructed `CacheInfo` now has the `cacheMissException` set as expected. 

I think this got dropped in some refactor perhaps. One of our tests would have caught this issue earlier, but it was ignored for a while. 