### PR TITLE
Add test for setting a client default NetworkFirst fetchPolicy

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/fetchPolicies.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/fetchPolicies.kt
@@ -21,22 +21,28 @@ internal val <D : Operation.Data> ApolloRequest<D>.fetchPolicyInterceptor
   get() = executionContext[FetchPolicyContext]?.interceptor ?: DefaultFetchPolicyInterceptor
 
 /**
- * Sets the initial [FetchPolicy]
- * This only has effects for queries. Mutations and subscriptions always use [FetchPolicy.NetworkOnly]
+ * Sets the fetch policy interceptor.
+ * 
+ * This only has effects for queries. Mutations and subscriptions always use [FetchPolicy.NetworkOnly].
+ * This overrides any fetch policy set with [fetchPolicy]. 
+ * 
+ * Default: [DefaultFetchPolicyInterceptor]
  */
 fun <T> MutableExecutionOptions<T>.fetchPolicyInterceptor(interceptor: ApolloInterceptor) = addExecutionContext(
     FetchPolicyContext(interceptor),
 )
 
 /**
- * Sets the initial [FetchPolicy]
+ * Sets the [FetchPolicy].
  * This only has effects for queries. Mutations and subscriptions always use the network only.
- *
+ * This overrides any fetch policy interceptor set with [fetchPolicyInterceptor].
+ * 
  * Default: [FetchPolicy.CacheFirst]
  */
 @Suppress("UNCHECKED_CAST")
 fun <T> MutableExecutionOptions<T>.fetchPolicy(fetchPolicy: FetchPolicy): T {
   // Reset first
+  fetchPolicyInterceptor(DefaultFetchPolicyInterceptor)
   onlyIfCached(false)
   noCache(false)
   return when (fetchPolicy) {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/refetchPolicy.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/refetchPolicy.kt
@@ -19,24 +19,31 @@ internal val <T> MutableExecutionOptions<T>.refetchPolicyInterceptor
   get() = executionContext[RefetchPolicyContext]?.interceptor ?: DefaultFetchPolicyInterceptor
 
 /**
- * Sets the [FetchPolicy] used when watching queries and a cache change has been published.
+ * Sets the fetch policy interceptor used when watching queries and a cache change has been published.
+ * 
+ * This overrides any fetch policy set with [refetchPolicy].
  *
- * Default: [FetchPolicy.CacheOnly]
+ * Default: [DefaultFetchPolicyInterceptor]
  */
 fun <T> MutableExecutionOptions<T>.refetchPolicyInterceptor(interceptor: ApolloInterceptor) = addExecutionContext(
     RefetchPolicyContext(interceptor),
 )
 
 /**
- * Sets the [FetchPolicy] used when watching queries and a cache change has been published
+ * Sets the [FetchPolicy] used when watching queries and a cache change has been published.
+ * 
+ * This overrides any fetch policy interceptor set with [refetchPolicyInterceptor].
+ * 
+ * Default: [FetchPolicy.CacheOnly]
  */
 @Suppress("UNCHECKED_CAST")
 fun <T> MutableExecutionOptions<T>.refetchPolicy(fetchPolicy: FetchPolicy): T {
   // Reset first
+  refetchPolicyInterceptor(DefaultFetchPolicyInterceptor)
   refetchOnlyIfCached(false)
   refetchNoCache(false)
   return when (fetchPolicy) {
-    FetchPolicy.NetworkFirst ->refetchPolicyInterceptor(NetworkFirstInterceptor)
+    FetchPolicy.NetworkFirst -> refetchPolicyInterceptor(NetworkFirstInterceptor)
     FetchPolicy.CacheOnly -> refetchOnlyIfCached(true)
     FetchPolicy.NetworkOnly -> refetchNoCache(true)
     FetchPolicy.CacheFirst -> this as T

--- a/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -192,6 +192,82 @@ class FetchPolicyTest {
           )
         }
   }
+
+  @Test
+  fun fetchPolicyQueryOverrideWithNetworkFirstClientDefault() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueueString(
+        // language=JSON
+        """
+        {
+          "data": {
+            "me": {
+              "__typename": "User",
+              "id": "1",
+              "firstName": "John",
+              "lastName": "Smith"
+            }
+          }
+        }
+      """.trimIndent()
+    )
+    ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .cache(MemoryCacheFactory())
+        // Unlike CacheOnly/NetworkOnly/CacheFirst, NetworkFirst (and CacheAndNetwork) is interceptor-based: it puts a FetchPolicyContext in the client execution context
+        .fetchPolicy(FetchPolicy.NetworkFirst)
+        .build()
+        .use { apolloClient ->
+          val networkResponse = apolloClient
+              .query(MeQuery())
+              .execute()
+          assertFalse(networkResponse.isFromCache)
+          assertEquals(
+              MeQuery.Data(
+                  MeQuery.Me(
+                      __typename = "User",
+                      id = "1",
+                      firstName = "John",
+                      lastName = "Smith",
+                  ),
+              ),
+              networkResponse.data,
+          )
+
+          // If the CacheOnly query below erroneously goes to the network, it receives this response, making the extra request visible to the assertions.
+          // Without a queued response, NetworkFirst would fall back to the cache on the failed network request and mask the bug.
+          mockServer.enqueueString(
+              // language=JSON
+              """
+              {
+                "data": {
+                  "me": {
+                    "__typename": "User",
+                    "id": "1",
+                    "firstName": "Jane",
+                    "lastName": "Doe"
+                  }
+                }
+              }
+            """.trimIndent()
+          )
+          val cacheResponse = apolloClient
+              .query(MeQuery())
+              .fetchPolicy(FetchPolicy.CacheOnly)
+              .execute()
+          assertTrue(cacheResponse.isFromCache)
+          assertEquals(
+              MeQuery.Data(
+                  MeQuery.Me(
+                      __typename = "User",
+                      id = "1",
+                      firstName = "John",
+                      lastName = "Smith",
+                  ),
+              ),
+              cacheResponse.data,
+          )
+        }
+  }
 }
 
 /**


### PR DESCRIPTION
This uses NetworkFirst for the client fetchPolicy, and ensures that the network is primed with an altered data response that proves that the query-specific fetchPolicy override is being ignored.

The test currently functions as a regression test – it fails until the underlying bug/behaviour is solved.

This is related to #364 