### PR TITLE
Avoid inserting identical records

### DIFF
--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
@@ -173,11 +173,11 @@ class SqlNormalizedCache internal constructor(
           val record = record.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
           val existingRecord = existingRecords[record.key]
           if (existingRecord == null) {
-            recordDatabase.insertOrUpdateRecord(record)
+            recordDatabase.insertOrUpdateRecord(record, deleteFirst = false)
             record.fieldKeys()
           } else {
             val (mergedRecord, changedKeys) = recordMerger.merge(RecordMergerContext(existing = existingRecord, incoming = record, cacheHeaders = cacheHeaders))
-            if (mergedRecord.isNotEmpty()) {
+            if (mergedRecord.isNotEmpty() && mergedRecord != existingRecord) {
               recordDatabase.insertOrUpdateRecord(mergedRecord)
             }
             changedKeys

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordDatabase.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordDatabase.kt
@@ -100,8 +100,8 @@ internal class RecordDatabase(
   /**
    * Must be called inside a transaction.
    */
-  suspend fun insertOrUpdateRecord(record: Record) {
-    recordQueries.deleteRecords(listOf(record.key.key))
+  suspend fun insertOrUpdateRecord(record: Record, deleteFirst: Boolean = true) {
+    if (deleteFirst) recordQueries.deleteRecords(listOf(record.key.key))
     val recordBytes = RecordSerializer.serialize(record)
     val updatedDate = currentTimeMillis()
     // Fast path for small records

--- a/normalized-cache-sqlite/src/jvmTest/kotlin/com/apollographql/cache/normalized/sql/JvmSqlNormalizedCacheTest.kt
+++ b/normalized-cache-sqlite/src/jvmTest/kotlin/com/apollographql/cache/normalized/sql/JvmSqlNormalizedCacheTest.kt
@@ -1,0 +1,93 @@
+package com.apollographql.cache.normalized.sql
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.apollographql.cache.normalized.api.CacheHeaders
+import com.apollographql.cache.normalized.api.CacheKey
+import com.apollographql.cache.normalized.api.DefaultRecordMerger
+import com.apollographql.cache.normalized.api.Record
+import com.apollographql.cache.normalized.sql.internal.RecordDatabase
+import com.apollographql.cache.normalized.testing.runTest
+import java.util.Properties
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JvmSqlNormalizedCacheTest {
+  @Test
+  fun mergingIdenticalRecordIsANoOp() = runTest {
+    val driver = SpyDriver(JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY, Properties()))
+    val cache = SqlNormalizedCache(RecordDatabase(driver, null))
+    // Initial insert
+    cache.merge(
+        record = Record(
+            key = CacheKey.QUERY_ROOT,
+            fields = mapOf(
+                "a" to "0",
+            ),
+        ),
+        cacheHeaders = CacheHeaders.NONE,
+        recordMerger = DefaultRecordMerger,
+    )
+    var count = driver.count
+
+    // Insert the same record
+    cache.merge(
+        record = Record(
+            key = CacheKey.QUERY_ROOT,
+            fields = mapOf(
+                "a" to "0",
+            ),
+        ),
+        cacheHeaders = CacheHeaders.NONE,
+        recordMerger = DefaultRecordMerger,
+    )
+
+    // Expected 1 select, 0 insert
+    assertEquals(1, driver.count - count)
+    count = driver.count
+
+    // Insert a different record
+    cache.merge(
+        record = Record(
+            key = CacheKey.QUERY_ROOT,
+            fields = mapOf(
+                "a" to "1",
+            ),
+        ),
+        cacheHeaders = CacheHeaders.NONE,
+        recordMerger = DefaultRecordMerger,
+    )
+
+    // Expected 1 select, 1 delete, 1 insert
+    assertEquals(3, driver.count - count)
+
+  }
+}
+
+private class SpyDriver(private val delegate: SqlDriver) : SqlDriver by delegate {
+  var count = 0
+
+  override fun execute(
+      identifier: Int?,
+      sql: String,
+      parameters: Int,
+      binders: (SqlPreparedStatement.() -> Unit)?,
+  ): QueryResult<Long> {
+    count++
+    return delegate.execute(identifier, sql, parameters, binders)
+  }
+
+  override fun <R> executeQuery(
+      identifier: Int?,
+      sql: String,
+      mapper: (SqlCursor) -> QueryResult<R>,
+      parameters: Int,
+      binders: (SqlPreparedStatement.() -> Unit)?,
+  ): QueryResult<R> {
+    count++
+    return delegate.executeQuery(identifier, sql, mapper, parameters, binders)
+  }
+}

--- a/normalized-cache/api/normalized-cache.api
+++ b/normalized-cache/api/normalized-cache.api
@@ -696,6 +696,7 @@ public final class com/apollographql/cache/normalized/api/Record : java/util/Map
 	public fun containsKey (Ljava/lang/String;)Z
 	public fun containsValue (Ljava/lang/Object;)Z
 	public final fun entrySet ()Ljava/util/Set;
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun fieldKeys ()Ljava/util/Set;
 	public final fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun get (Ljava/lang/String;)Ljava/lang/Object;
@@ -708,6 +709,7 @@ public final class com/apollographql/cache/normalized/api/Record : java/util/Map
 	public fun getSize ()I
 	public final fun getSizeInBytes ()I
 	public fun getValues ()Ljava/util/Collection;
+	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public final fun keySet ()Ljava/util/Set;
 	public synthetic fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;

--- a/normalized-cache/api/normalized-cache.klib.api
+++ b/normalized-cache/api/normalized-cache.klib.api
@@ -370,8 +370,10 @@ final class com.apollographql.cache.normalized.api/Record : kotlin.collections/M
 
     final fun containsKey(kotlin/String): kotlin/Boolean // com.apollographql.cache.normalized.api/Record.containsKey|containsKey(kotlin.String){}[0]
     final fun containsValue(kotlin/Any?): kotlin/Boolean // com.apollographql.cache.normalized.api/Record.containsValue|containsValue(kotlin.Any?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.apollographql.cache.normalized.api/Record.equals|equals(kotlin.Any?){}[0]
     final fun fieldKeys(): kotlin.collections/Set<kotlin/String> // com.apollographql.cache.normalized.api/Record.fieldKeys|fieldKeys(){}[0]
     final fun get(kotlin/String): kotlin/Any? // com.apollographql.cache.normalized.api/Record.get|get(kotlin.String){}[0]
+    final fun hashCode(): kotlin/Int // com.apollographql.cache.normalized.api/Record.hashCode|hashCode(){}[0]
     final fun isEmpty(): kotlin/Boolean // com.apollographql.cache.normalized.api/Record.isEmpty|isEmpty(){}[0]
     final fun mergeWith(com.apollographql.cache.normalized.api/Record): kotlin/Pair<com.apollographql.cache.normalized.api/Record, kotlin.collections/Set<kotlin/String>> // com.apollographql.cache.normalized.api/Record.mergeWith|mergeWith(com.apollographql.cache.normalized.api.Record){}[0]
     final fun referencedFields(): kotlin.collections/List<com.apollographql.cache.normalized.api/CacheKey> // com.apollographql.cache.normalized.api/Record.referencedFields|referencedFields(){}[0]

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/Record.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/Record.kt
@@ -57,6 +57,24 @@ class Record(
     return result
   }
 
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Record) return false
+
+    if (key != other.key) return false
+    if (fields != other.fields) return false
+    if (metadata != other.metadata) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = key.hashCode()
+    result = 31 * result + fields.hashCode()
+    result = 31 * result + metadata.hashCode()
+    return result
+  }
+
   companion object {
     internal fun changedKeys(record1: Record, record2: Record): Set<String> {
       check(record1.key == record2.key) {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
@@ -130,8 +130,10 @@ class MemoryCache(
           record.fieldKeys()
         } else {
           val (mergedRecord, changedKeys) = recordMerger.merge(RecordMergerContext(existing = existingRecord, incoming = record, cacheHeaders = cacheHeaders))
-          recordsToInsert.add(mergedRecord)
-          lruCache[record.key] = mergedRecord
+          if (mergedRecord != existingRecord) {
+            recordsToInsert.add(mergedRecord)
+            lruCache[record.key] = mergedRecord
+          }
           changedKeys
         }
       }.toSet()


### PR DESCRIPTION
An optimization: if the result of a merge is identical to the existing record it's not useful to store it again.

Bonus optimization: if a record is new, a delete operation is not needed.