### PR TITLE
Defer sqlite driver creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 PUT_CHANGELOG_HERE
 
+- [Fix] `SqlNormalizedCacheFactory()` no longer touches the disk when called, fixing a StrictMode main thread disk read. The driver is now created in `NormalizedCacheFactory.create()` (#373)
+
 # v1.0.6
 _2026-07-17_
 

--- a/normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.android.kt
+++ b/normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.android.kt
@@ -7,7 +7,9 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.apollographql.apollo.exception.apolloExceptionHandler
+import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.sql.internal.RecordDatabase
 import com.apollographql.cache.normalized.sql.internal.record.SqlRecordDatabase
 
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory =
@@ -30,50 +32,50 @@ fun SqlNormalizedCacheFactory(
     configure: ((SupportSQLiteDatabase) -> Unit)? = null,
     useNoBackupDirectory: Boolean = false,
     windowSizeBytes: Long? = 4 * 1024 * 1024,
-): NormalizedCacheFactory {
-  val synchronousSchema = SqlRecordDatabase.Schema.synchronous()
-  val filePath = when {
-    name == null -> {
-      null
-    }
+): NormalizedCacheFactory = object : NormalizedCacheFactory() {
+  override fun create(): NormalizedCache {
+    val synchronousSchema = SqlRecordDatabase.Schema.synchronous()
+    val filePath = when {
+      name == null -> {
+        null
+      }
 
-    name.startsWith("/") -> {
-      // Absolute path: keep as-is
-      name
-    }
+      name.startsWith("/") -> {
+        // Absolute path: keep as-is
+        name
+      }
 
-    else -> {
-      // Old versions of the library used to store the database in the database directory.
-      // If such file exists, use it, otherwise, use the cache directory.
-      (context.getDatabasePath(name).takeIf { it.exists() } ?: context.cacheDir.resolve(name)).absolutePath
+      else -> {
+        // Old versions of the library used to store the database in the database directory.
+        // If such file exists, use it, otherwise, use the cache directory.
+        (context.getDatabasePath(name).takeIf { it.exists() } ?: context.cacheDir.resolve(name)).absolutePath
+      }
     }
+    val driver = AndroidSqliteDriver(
+        schema = synchronousSchema,
+        context = context.applicationContext,
+        name = filePath,
+        factory = factory,
+        callback = object : AndroidSqliteDriver.Callback(synchronousSchema) {
+          override fun onConfigure(db: SupportSQLiteDatabase) {
+            super.onConfigure(db)
+            configure?.invoke(db)
+          }
+
+          override fun onCorruption(db: SupportSQLiteDatabase) {
+            apolloExceptionHandler(Exception("Corruption detected, recreating the database"))
+            super.onCorruption(db)
+          }
+
+          override fun onDowngrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
+            // Treat downgrades as corruption, which results in a clean database
+            apolloExceptionHandler(Exception("onDowngrade from $oldVersion to $newVersion, treating as database corruption"))
+            super.onCorruption(db)
+          }
+        },
+        useNoBackupDirectory = useNoBackupDirectory,
+        windowSizeBytes = windowSizeBytes,
+    )
+    return SqlNormalizedCache(RecordDatabase(driver, filePath))
   }
-  return SqlNormalizedCacheFactory(
-      driver = AndroidSqliteDriver(
-          schema = synchronousSchema,
-          context = context.applicationContext,
-          name = filePath,
-          factory = factory,
-          callback = object : AndroidSqliteDriver.Callback(synchronousSchema) {
-            override fun onConfigure(db: SupportSQLiteDatabase) {
-              super.onConfigure(db)
-              configure?.invoke(db)
-            }
-
-            override fun onCorruption(db: SupportSQLiteDatabase) {
-              apolloExceptionHandler(Exception("Corruption detected, recreating the database"))
-              super.onCorruption(db)
-            }
-
-            override fun onDowngrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
-              // Treat downgrades as corruption, which results in a clean database
-              apolloExceptionHandler(Exception("onDowngrade from $oldVersion to $newVersion, treating as database corruption"))
-              super.onCorruption(db)
-            }
-          },
-          useNoBackupDirectory = useNoBackupDirectory,
-          windowSizeBytes = windowSizeBytes,
-      ),
-      name = filePath,
-  )
 }

--- a/normalized-cache-sqlite/src/appleMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.apple.kt
+++ b/normalized-cache-sqlite/src/appleMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.apple.kt
@@ -5,7 +5,9 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import app.cash.sqldelight.driver.native.wrapConnection
 import co.touchlab.sqliter.DatabaseConfiguration
+import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.sql.internal.RecordDatabase
 import com.apollographql.cache.normalized.sql.internal.record.SqlRecordDatabase
 
 /**
@@ -17,7 +19,11 @@ import com.apollographql.cache.normalized.sql.internal.record.SqlRecordDatabase
 fun SqlNormalizedCacheFactory(
     name: String?,
     baseDir: String?,
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(createDriver(name, baseDir), name)
+): NormalizedCacheFactory = object : NormalizedCacheFactory() {
+  override fun create(): NormalizedCache {
+    return SqlNormalizedCache(RecordDatabase(createDriver(name, baseDir), name))
+  }
+}
 
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory = SqlNormalizedCacheFactory(name, null)
 

--- a/normalized-cache-sqlite/src/jsCommonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jsCommon.kt
+++ b/normalized-cache-sqlite/src/jsCommonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jsCommon.kt
@@ -1,7 +1,9 @@
 package com.apollographql.cache.normalized.sql
 
 import app.cash.sqldelight.driver.worker.createDefaultWebWorkerDriver
+import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.sql.internal.RecordDatabase
 
 /**
  * Returns a SqlNormalizedCacheFactory configured with the default driver which works with SQL.js.
@@ -14,7 +16,9 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
  *
  * See [the SQLDelight documentation](https://sqldelight.github.io/sqldelight/2.1.0/js_sqlite/sqljs_worker/).
  */
-actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory {
-  return SqlNormalizedCacheFactory(createDefaultWebWorkerDriver(), name = null)
+actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory = object : NormalizedCacheFactory() {
+  override fun create(): NormalizedCache {
+    return SqlNormalizedCache(RecordDatabase(createDefaultWebWorkerDriver(), name = null))
+  }
 }
 

--- a/normalized-cache-sqlite/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jvm.kt
+++ b/normalized-cache-sqlite/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheFactory.jvm.kt
@@ -1,7 +1,9 @@
 package com.apollographql.cache.normalized.sql
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.sql.internal.RecordDatabase
 import java.io.File
 import java.util.Properties
 
@@ -13,7 +15,11 @@ import java.util.Properties
 fun SqlNormalizedCacheFactory(
     url: String,
     properties: Properties,
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(JdbcSqliteDriver(url, properties), name = null)
+): NormalizedCacheFactory = object : NormalizedCacheFactory() {
+  override fun create(): NormalizedCache {
+    return SqlNormalizedCache(RecordDatabase(JdbcSqliteDriver(url, properties), name = null))
+  }
+}
 
 /**
  * @param name the name of the database or null for an in-memory database
@@ -24,7 +30,11 @@ fun SqlNormalizedCacheFactory(
 fun SqlNormalizedCacheFactory(
     name: String?,
     baseDir: String?,
-): NormalizedCacheFactory = SqlNormalizedCacheFactory(JdbcSqliteDriver(name.toUrl(baseDir), Properties()), name = name)
+): NormalizedCacheFactory = object : NormalizedCacheFactory() {
+  override fun create(): NormalizedCache {
+    return SqlNormalizedCache(RecordDatabase(JdbcSqliteDriver(name.toUrl(baseDir), Properties()), name = name))
+  }
+}
 
 actual fun SqlNormalizedCacheFactory(name: String?): NormalizedCacheFactory = SqlNormalizedCacheFactory(name, null)
 

--- a/normalized-cache-sqlite/src/jvmTest/kotlin/com/apollographql/cache/normalized/sql/JvmSqlNormalizedCacheTest.kt
+++ b/normalized-cache-sqlite/src/jvmTest/kotlin/com/apollographql/cache/normalized/sql/JvmSqlNormalizedCacheTest.kt
@@ -11,11 +11,30 @@ import com.apollographql.cache.normalized.api.DefaultRecordMerger
 import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.sql.internal.RecordDatabase
 import com.apollographql.cache.normalized.testing.runTest
+import java.io.File
 import java.util.Properties
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class JvmSqlNormalizedCacheTest {
+  @Test
+  fun theDatabaseIsNotCreatedUntilTheCacheIs() {
+    val baseDir = File(System.getProperty("java.io.tmpdir"), "apollo-test-${System.nanoTime()}")
+    try {
+      val factory = SqlNormalizedCacheFactory(name = "test.db", baseDir = baseDir.path)
+
+      // Creating the factory must not touch the disk.
+      assertFalse(baseDir.exists(), "The base directory must not be created before NormalizedCacheFactory.create()")
+
+      factory.create()
+      assertTrue(baseDir.exists(), "The base directory must be created by NormalizedCacheFactory.create()")
+    } finally {
+      baseDir.deleteRecursively()
+    }
+  }
+
   @Test
   fun mergingIdenticalRecordIsANoOp() = runTest {
     val driver = SpyDriver(JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY, Properties()))


### PR DESCRIPTION
## Defer SQLite driver creation to `NormalizedCacheFactory.create()`

Building an `ApolloClient` with `SqlNormalizedCacheFactory()` trips StrictMode with a
main thread disk read on Android. The factory functions resolve the database path and
build the driver as soon as they are called, which is usually on the main thread while
the client is being built.

- `dc39b49` Every platform factory now does its work inside `create()`. `SqlNormalizedCache` takes
the driver and name directly and owns its `RecordDatabase`, so the factories no longer
build one.

- `3eeaa6b` Make `NormalizedCacheFactory` a `fun interface`.
Mostly cosmetic: it lets the factories be written as lambdas rather than
`object : NormalizedCacheFactory() { override fun create() … }`, which removes the same
boilerplate repeated at five call sites.
**This commit is source and binary breaking**. It is kept separate so
commit 1 can be merged on its own if you would rather not take the break now.