### PR TITLE
Fetch the initial responses of watch() from the watcher interceptor 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [Improvement] Derive the keys a watcher matches cache changes against lazily, keeping the re-normalization of the whole response off the path that delivers the initial responses of `watch` (#378)
 - [Improvement] Reduce allocations when deriving a watcher's dependent keys and matching them against a cache change (#378)
 - [Improvement] `watch` now runs the operation through the interceptor chain once instead of twice. Its initial responses are fetched by the watcher interceptor, so the last of them no longer waits on a second execution of the chain to subscribe to the cache. Interceptors installed ahead of the cache run once per `watch` (#379)
+- [Fix] Cache headers set on the client are no longer discarded by a call that sets cache headers of its own. Whether the two were merged used to depend on the order the options were set in (#379)
 - Enable parallel sync for Tooling API clients (#380)
 
 PUT_CHANGELOG_HERE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Improvement] Derive the keys a watcher matches cache changes against lazily, keeping the re-normalization of the whole response off the path that delivers the initial responses of `watch` (#378)
 - [Improvement] Reduce allocations when deriving a watcher's dependent keys and matching them against a cache change (#378)
+- [Improvement] `watch` now runs the operation through the interceptor chain once instead of twice. Its initial responses are fetched by the watcher interceptor, so the last of them no longer waits on a second execution of the chain to subscribe to the cache. Interceptors installed ahead of the cache run once per `watch` (#379)
 - Enable parallel sync for Tooling API clients (#380)
 
 PUT_CHANGELOG_HERE

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
@@ -10,13 +10,21 @@ import com.apollographql.apollo.exception.DefaultApolloException
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.cache.normalized.CacheManager
+import com.apollographql.cache.normalized.DefaultFetchPolicyInterceptor
+import com.apollographql.cache.normalized.FetchPolicyContext
+import com.apollographql.cache.normalized.RefetchPolicyContext
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.dependentKeys
 import com.apollographql.cache.normalized.api.withErrors
+import com.apollographql.cache.normalized.options.noCache
+import com.apollographql.cache.normalized.options.onlyIfCached
+import com.apollographql.cache.normalized.options.refetchNoCache
+import com.apollographql.cache.normalized.options.refetchOnlyIfCached
 import com.apollographql.cache.normalized.watchContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.transform
@@ -40,11 +48,11 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
      * operations. The keys are only ever read to filter an incoming cache change, so they are
      * computed on the first such change rather than up front.
      *
-     * This matters because of when the work would otherwise happen:
-     * [com.apollographql.cache.normalized.watch] withholds the last of its initial responses until
-     * this interceptor has subscribed to [CacheManager.changedKeys], so anything done before
-     * subscribing delays that response reaching the caller. The same applies to the responses of a
-     * refetch below, which is why those only record the data and leave the keys stale.
+     * This matters because of when the work would otherwise happen: the last of the initial
+     * responses is withheld below until this interceptor has subscribed to
+     * [CacheManager.changedKeys], so anything done before subscribing delays that response reaching
+     * the caller. The same applies to the responses of a refetch, which is why those only record the
+     * data and leave the keys stale.
      */
     var dataToWatch: Operation.Data? = watchContext.data
     var errorsToWatch: List<Error>? = null
@@ -75,6 +83,36 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
       }
     }
 
+    /**
+     * The request used when the cache changes.
+     *
+     * `watch()` fetches its initial responses with the fetch policy and refetches with the refetch
+     * policy, so the latter has to be applied here rather than to the whole call. `watch(data)` has
+     * no initial fetch and keeps the fetch policy throughout.
+     */
+    val refetchRequest = if (watchContext.fetchInitialResponses) {
+      request.newBuilder()
+          .addExecutionContext(
+              FetchPolicyContext(request.executionContext[RefetchPolicyContext]?.interceptor ?: DefaultFetchPolicyInterceptor),
+          )
+          .noCache(request.refetchNoCache)
+          .onlyIfCached(request.refetchOnlyIfCached)
+          .build()
+    } else {
+      request
+    }
+
+    fun proceedRecordingData(request: ApolloRequest<D>): Flow<ApolloResponse<D>> {
+      return chain.proceed(request)
+          .onEach { response ->
+            if (response.data != null) {
+              dataToWatch = response.data
+              errorsToWatch = response.errors
+              watchedKeysAreStale = true
+            }
+          }
+    }
+
     fun isWatched(changedKeys: Set<*>): Boolean {
       if (changedKeys === CacheManager.ALL_KEYS) {
         // Matches regardless of the watched keys, so there is no need to compute them.
@@ -87,30 +125,58 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
       return (changedKeys as Set<String>).anyIntersection(watched)
     }
 
-    return (cacheManager.changedKeys as SharedFlow<Any>)
-        .onSubscription {
-          emit(Unit)
+    return flow {
+      /**
+       * The last of the initial responses, withheld until the cache subscription is established so
+       * that callers can use it as a synchronisation point: modifying the store once it arrives is
+       * guaranteed to be observed. Subscribing first instead would make the watcher fire on the
+       * initial fetch's own write.
+       *
+       * See https://github.com/apollographql/apollo-kotlin/pull/3853
+       */
+      var lastResponse: ApolloResponse<D>? = null
+
+      if (watchContext.fetchInitialResponses) {
+        proceedRecordingData(request).collect { response ->
+          if (response.isLast) {
+            /**
+             * If we ever come here it means some interceptors built a new Flow and forgot to reset the isLast flag
+             * Better safe than sorry: emit them when we realize that. This will introduce a delay in the response.
+             */
+            lastResponse?.let { emit(it) }
+            lastResponse = response
+          } else {
+            emit(response)
+          }
         }
-        .transform { event ->
-          if (event !is Set<*>) {
-            // The marker emitted by `onSubscription`. Answered without computing the watched keys,
-            // so that the initial response of `watch` is not held back by normalization.
-            emit(ApolloResponse.Builder(request.operation, request.requestUuid).exception(WatcherSentinel).build())
-            return@transform
-          }
-          if (!isWatched(event)) {
-            return@transform
-          }
-          emitAll(
-              chain.proceed(request)
-                  .onEach { response ->
-                    if (response.data != null) {
-                      dataToWatch = response.data
-                      errorsToWatch = response.errors
-                      watchedKeysAreStale = true
-                    }
+      }
+
+      emitAll(
+          (cacheManager.changedKeys as SharedFlow<Any>)
+              .onSubscription {
+                emit(Unit)
+              }
+              .transform { event ->
+                if (event !is Set<*>) {
+                  // The marker emitted by `onSubscription`: subscribed, so the withheld response can
+                  // be released. Reaching this point costs a `SharedFlow` subscription and nothing
+                  // else, because the initial responses were fetched from this same execution of the
+                  // interceptor chain.
+                  val held = lastResponse
+                  if (held != null) {
+                    lastResponse = null
+                    emit(held)
+                  } else if (!watchContext.fetchInitialResponses) {
+                    emit(ApolloResponse.Builder(request.operation, request.requestUuid).exception(WatcherSentinel).build())
                   }
-          )
-        }
+                  return@transform
+                }
+                if (!isWatched(event)) {
+                  return@transform
+                }
+                emitAll(proceedRecordingData(refetchRequest))
+              }
+      )
+    }
   }
 }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
@@ -128,7 +128,7 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
     return flow {
       /**
        * The last of the initial responses, withheld until the cache subscription is established so
-       * that callers can use it as a synchronisation point: modifying the store once it arrives is
+       * that callers can use it as a synchronization point: modifying the store once it arrives is
        * guaranteed to be observed. Subscribing first instead would make the watcher fire on the
        * initial fetch's own write.
        *

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/cacheHeaders.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/cacheHeaders.kt
@@ -11,30 +11,42 @@ import com.apollographql.cache.normalized.api.ApolloCacheHeaders
 import com.apollographql.cache.normalized.api.CacheHeaders
 import kotlin.time.Duration
 
+/**
+ * [CacheHeaders] carried by an [ExecutionContext].
+ *
+ * Several of these can coexist in one context — the client sets some, the call adds more — and they
+ * are merged when read, later ones winning. This is why every instance carries its own [key]:
+ * [ExecutionContext.plus] drops elements whose key is already present, so a shared key would let the
+ * headers of a call silently discard those of its client.
+ *
+ * Merging in [fold] instead does not work: [ExecutionContext.plus] only reaches an element's `fold`
+ * when it happens to sit at the far left of the combined context, so whether the headers merged
+ * depended on the order the options were set in.
+ */
 internal class CacheHeadersContext(val value: CacheHeaders) : ExecutionContext.Element {
-  override val key: ExecutionContext.Key<*>
-    get() = Key
+  override val key: ExecutionContext.Key<*> = Key()
 
-  /**
-   * Merge the [CacheHeaders] instead of letting the right element replace the right element.
-   */
-  override fun <R> fold(initial: R, operation: (R, ExecutionContext.Element) -> R): R {
-    val existing = (initial as? ExecutionContext)?.get(Key)
-    val element = if (existing != null) CacheHeadersContext(existing.value + value) else this
-    return operation(initial, element)
+  private class Key : ExecutionContext.Key<CacheHeadersContext>
+}
+
+private fun ExecutionContext.foldCacheHeaders(): CacheHeaders {
+  var merged: CacheHeaders? = null
+  fold(Unit) { _, element ->
+    if (element is CacheHeadersContext) {
+      merged = merged?.plus(element.value) ?: element.value
+    }
   }
-
-  companion object Key : ExecutionContext.Key<CacheHeadersContext>
+  return merged ?: CacheHeaders.NONE
 }
 
 internal val ExecutionOptions.cacheHeaders: CacheHeaders
-  get() = (executionContext[CacheHeadersContext]?.value ?: CacheHeaders.NONE)
+  get() = executionContext.foldCacheHeaders()
 
 fun <D : Operation.Data> ApolloResponse.Builder<D>.cacheHeaders(cacheHeaders: CacheHeaders) =
   addExecutionContext(CacheHeadersContext(cacheHeaders))
 
 val <D : Operation.Data> ApolloResponse<D>.cacheHeaders
-  get() = executionContext[CacheHeadersContext]?.value ?: CacheHeaders.NONE
+  get() = executionContext.foldCacheHeaders()
 
 
 /**
@@ -48,7 +60,7 @@ fun <T> MutableExecutionOptions<T>.cacheHeaders(cacheHeaders: CacheHeaders) = ad
  * Add a cache header to be passed to your [com.apollographql.cache.normalized.api.NormalizedCache]
  */
 fun <T> MutableExecutionOptions<T>.addCacheHeader(key: String, value: String) = cacheHeaders(
-    cacheHeaders.newBuilder().addHeader(key, value).build()
+    CacheHeaders.Builder().addHeader(key, value).build()
 )
 
 /**

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/cacheHeaders.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/cacheHeaders.kt
@@ -11,42 +11,28 @@ import com.apollographql.cache.normalized.api.ApolloCacheHeaders
 import com.apollographql.cache.normalized.api.CacheHeaders
 import kotlin.time.Duration
 
-/**
- * [CacheHeaders] carried by an [ExecutionContext].
- *
- * Several of these can coexist in one context — the client sets some, the call adds more — and they
- * are merged when read, later ones winning. This is why every instance carries its own [key]:
- * [ExecutionContext.plus] drops elements whose key is already present, so a shared key would let the
- * headers of a call silently discard those of its client.
- *
- * Merging in [fold] instead does not work: [ExecutionContext.plus] only reaches an element's `fold`
- * when it happens to sit at the far left of the combined context, so whether the headers merged
- * depended on the order the options were set in.
- */
 internal class CacheHeadersContext(val value: CacheHeaders) : ExecutionContext.Element {
+  /**
+   * Each [CacheHeadersContext] gets a unique key, so headers are merged as expected.
+   */
   override val key: ExecutionContext.Key<*> = Key()
 
   private class Key : ExecutionContext.Key<CacheHeadersContext>
 }
 
-private fun ExecutionContext.foldCacheHeaders(): CacheHeaders {
-  var merged: CacheHeaders? = null
-  fold(Unit) { _, element ->
-    if (element is CacheHeadersContext) {
-      merged = merged?.plus(element.value) ?: element.value
-    }
+private fun ExecutionContext.mergedCacheHeaders(): CacheHeaders =
+  fold(CacheHeaders.NONE) { acc, element ->
+    if (element is CacheHeadersContext) acc + element.value else acc
   }
-  return merged ?: CacheHeaders.NONE
-}
 
 internal val ExecutionOptions.cacheHeaders: CacheHeaders
-  get() = executionContext.foldCacheHeaders()
+  get() = executionContext.mergedCacheHeaders()
 
 fun <D : Operation.Data> ApolloResponse.Builder<D>.cacheHeaders(cacheHeaders: CacheHeaders) =
   addExecutionContext(CacheHeadersContext(cacheHeaders))
 
 val <D : Operation.Data> ApolloResponse<D>.cacheHeaders
-  get() = executionContext.foldCacheHeaders()
+  get() = executionContext.mergedCacheHeaders()
 
 
 /**

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/watch.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/watch.kt
@@ -9,13 +9,8 @@ import com.apollographql.apollo.api.ExecutionContext
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Query
 import com.apollographql.cache.normalized.internal.WatcherSentinel
-import com.apollographql.cache.normalized.options.noCache
-import com.apollographql.cache.normalized.options.onlyIfCached
-import com.apollographql.cache.normalized.options.refetchNoCache
-import com.apollographql.cache.normalized.options.refetchOnlyIfCached
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flow
 
 internal class WatchContext(
     /**
@@ -75,17 +70,13 @@ fun <D : Query.Data> ApolloCall<D>.watch(): Flow<ApolloResponse<D>> {
 }
 
 /**
- * Observes the cache for the given data. Unlike [watch], no initial request is executed on the network.
+ * Observes the cache for the given data. Unlike the version of `watch` that takes no argument,
+ * no initial request is executed on the network.
  * The fetch policy set by [fetchPolicy] will be used.
  */
 fun <D : Query.Data> ApolloCall<D>.watch(data: D?): Flow<ApolloResponse<D>> {
-  return watchInternal(data).filter { it.exception !== WatcherSentinel }
-}
-
-/**
- * Observes the cache for the given data. Unlike [watch], no initial request is executed on the network.
- * The fetch policy set by [fetchPolicy] will be used.
- */
-internal fun <D : Query.Data> ApolloCall<D>.watchInternal(data: D?): Flow<ApolloResponse<D>> {
-  return copy().addExecutionContext(WatchContext(data, fetchInitialResponses = false)).toFlow()
+  return copy()
+      .addExecutionContext(WatchContext(data, fetchInitialResponses = false))
+      .toFlow()
+      .filter { it.exception !== WatcherSentinel }
 }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/watch.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/watch.kt
@@ -18,7 +18,18 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 
 internal class WatchContext(
+    /**
+     * The data to derive the initially watched keys from, for the overload that does not fetch.
+     */
     val data: Query.Data?,
+
+    /**
+     * Whether to execute the request once, with the fetch policy, before observing the cache.
+     *
+     * Doing this from the interceptor rather than as a separate execution means the operation goes
+     * through the interceptor chain once instead of twice.
+     */
+    val fetchInitialResponses: Boolean,
 ) : ExecutionContext.Element {
   override val key: ExecutionContext.Key<*>
     get() = Key
@@ -33,8 +44,8 @@ internal val <D : Operation.Data> ApolloRequest<D>.watchContext: WatchContext?
 /**
  * Gets initial response(s) then observes the cache for any changes.
  *
- * The cache subscription is established before the initial fetch completes, so any external cache update made
- * after collecting the last initial response will be received.
+ * The cache subscription is established before the last initial response is collected, so any external cache update made
+ * after collecting it will be received.
  *
  * Note: when using [writeToCacheAsynchronously], the cache updates are postponed and behave as external cache updates. They may trigger emission. 
  *
@@ -46,53 +57,21 @@ internal val <D : Operation.Data> ApolloRequest<D>.watchContext: WatchContext?
  * @see refetchPolicy
  */
 fun <D : Query.Data> ApolloCall<D>.watch(): Flow<ApolloResponse<D>> {
-  return flow {
-    var lastResponse: ApolloResponse<D>? = null
-    var response: ApolloResponse<D>? = null
-
-    toFlow()
-        .collect {
-          response = it
-
-          if (it.isLast) {
-            if (lastResponse != null) {
-              /**
-               * If we ever come here it means some interceptors built a new Flow and forgot to reset the isLast flag
-               * Better safe than sorry: emit them when we realize that. This will introduce a delay in the response.
-               */
-              println("ApolloGraphQL: extra response received after the last one")
-              emit(lastResponse!!)
-            }
-            /**
-             * Remember the last response so that we can send it after we subscribe to the store
-             *
-             * This allows callers to use the last element as a synchronisation point to modify the store and still have the watcher
-             * receive subsequent updates
-             *
-             * See https://github.com/apollographql/apollo-kotlin/pull/3853
-             */
-            lastResponse = it
-          } else {
-            emit(it)
-          }
-        }
-
-
-    copy().fetchPolicyInterceptor(refetchPolicyInterceptor)
-        .noCache(refetchNoCache)
-        .onlyIfCached(refetchOnlyIfCached)
-        .watchInternal(response?.data)
-        .collect {
-          if (it.exception === WatcherSentinel) {
-            if (lastResponse != null) {
-              emit(lastResponse!!)
-              lastResponse = null
-            }
-          } else {
-            emit(it)
-          }
-        }
-  }
+  /**
+   * The initial responses are fetched by the interceptor, which subscribes to the cache right after
+   * and only then releases the last of them.
+   *
+   * Executing them here instead would mean a second trip through the interceptor chain to subscribe,
+   * and that last response would be withheld until the trip finished - delaying it by the teardown
+   * of the first flow, a dispatch, and a re-run of every interceptor ahead of the cache. Done from
+   * the interceptor, the wait is a [kotlinx.coroutines.flow.SharedFlow] subscription and nothing
+   * else, while the synchronisation point callers rely on is unchanged.
+   *
+   * See https://github.com/apollographql/apollo-kotlin/pull/3853
+   */
+  return copy()
+      .addExecutionContext(WatchContext(data = null, fetchInitialResponses = true))
+      .toFlow()
 }
 
 /**
@@ -108,5 +87,5 @@ fun <D : Query.Data> ApolloCall<D>.watch(data: D?): Flow<ApolloResponse<D>> {
  * The fetch policy set by [fetchPolicy] will be used.
  */
 internal fun <D : Query.Data> ApolloCall<D>.watchInternal(data: D?): Flow<ApolloResponse<D>> {
-  return copy().addExecutionContext(WatchContext(data)).toFlow()
+  return copy().addExecutionContext(WatchContext(data, fetchInitialResponses = false)).toFlow()
 }

--- a/tests/cache-options/src/commonTest/kotlin/test/CacheOptionsTest.kt
+++ b/tests/cache-options/src/commonTest/kotlin/test/CacheOptionsTest.kt
@@ -1073,6 +1073,61 @@ class CacheOptionsTest {
           }
         }
   }
+
+  /**
+   * Setting a cache header on a call must not discard the ones set on the client: both end up in the
+   * same [com.apollographql.apollo.api.ExecutionContext] and have to be merged.
+   */
+  @Test
+  fun clientCacheHeadersSurviveCallCacheHeaders() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueueString(
+        // language=JSON
+        """
+          {
+            "data": {
+              "car": {
+                "__typename": "Car",
+                "id": "1",
+                "color": "Red",
+                "doors": null
+              }
+            },
+            "errors": [
+              {
+                "message": "Doors does not exist",
+                "path": ["car", "doors"]
+              }
+            ]
+          }
+          """,
+    )
+
+    ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .serverErrorsAsException(false)
+        .cacheManager(memoryThenSqlCacheManager)
+        .build()
+        .use { apolloClient ->
+          apolloClient.query(GetCarQuery(carId = "1"))
+              .fetchPolicy(FetchPolicy.NetworkOnly)
+              .execute()
+
+          val cacheResponse = apolloClient.query(GetCarQuery(carId = "1"))
+              .fetchPolicy(FetchPolicy.CacheOnly)
+              // A cache header of the call's own, which the client's must be merged with rather than
+              // replaced by.
+              .memoryCacheOnly(true)
+              .execute()
+
+          // serverErrorsAsException is false, so the stored error is in errors and not thrown
+          assertNull(cacheResponse.exception)
+          assertEquals("Red", cacheResponse.data?.car?.color)
+          assertErrorsEquals(
+              listOf(Error.Builder("Doors does not exist").path(listOf("car", "doors")).build()),
+              cacheResponse.errors,
+          )
+        }
+  }
 }
 
 private fun <D : Operation.Data> ApolloCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> {

--- a/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
@@ -32,7 +32,6 @@ import com.apollographql.mockserver.enqueueString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
@@ -51,6 +50,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
 class WatcherTest {
@@ -92,7 +92,6 @@ class WatcherTest {
       )
   )
 
-  @OptIn(ExperimentalCoroutinesApi::class)
   private fun myRunTest(block: suspend CoroutineScope.() -> Unit) {
     kotlinx.coroutines.test.runTest(timeout = 10.minutes) {
       withContext(Dispatchers.Default.limitedParallelism(1)) {
@@ -126,12 +125,12 @@ class WatcherTest {
         }
       }
 
-      assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+      assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
       // Another newer call gets updated information with "Artoo"
       apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
-      assertEquals(channel.awaitElement()?.hero?.name, "Artoo")
+      assertEquals("Artoo", channel.awaitElement()?.hero?.name)
 
       job.cancel()
     }
@@ -159,7 +158,7 @@ class WatcherTest {
     // Update the cache
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -181,7 +180,7 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // Someone writes to the store directly
     val data = EpisodeHeroNameWithIdQuery.Data(
@@ -194,7 +193,7 @@ class WatcherTest {
 
     cacheManager.writeOperation(operation, data, publish = true)
 
-    assertEquals(channel.awaitElement()?.hero?.name, "Artoo")
+    assertEquals("Artoo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -217,7 +216,7 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // Another newer call gets the same name (R2-D2)
     apolloClient.enqueueTestResponse(query, episodeHeroNameData)
@@ -246,7 +245,7 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // Another newer call gets updated information with "Artoo"
     val heroAndFriendsNamesWithIDsQuery = HeroAndFriendsNamesWithIDsQuery(Episode.NEWHOPE)
@@ -256,7 +255,7 @@ class WatcherTest {
         .execute()
 
 
-    assertEquals(channel.awaitElement()?.hero?.name, "Artoo")
+    assertEquals("Artoo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -276,7 +275,7 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // Clear the cache
     cacheManager.clearAll().also { cacheManager.publish(CacheManager.ALL_KEYS) }
@@ -313,7 +312,7 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.receive()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.receive()?.hero?.name)
 
     // Another newer call gets the same information
     val heroAndFriendsNamesWithIDsQuery = HeroAndFriendsNamesWithIDsQuery(Episode.NEWHOPE)
@@ -347,7 +346,7 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // An overlapping query triggers a refetch, which is where the watched keys are refreshed
     val heroAndFriendsNamesWithIDsQuery = HeroAndFriendsNamesWithIDsQuery(Episode.NEWHOPE)
@@ -356,7 +355,7 @@ class WatcherTest {
         .fetchPolicy(FetchPolicy.NetworkOnly)
         .execute()
 
-    assertEquals(channel.awaitElement()?.hero?.name, "Artoo")
+    assertEquals("Artoo", channel.awaitElement()?.hero?.name)
 
     // A query sharing no key with the watched one is still filtered out after that refetch
     val starshipByIdQuery = StarshipByIdQuery("Starship1")
@@ -373,7 +372,7 @@ class WatcherTest {
         .fetchPolicy(FetchPolicy.NetworkOnly)
         .execute()
 
-    assertEquals(channel.awaitElement()?.hero?.name, "ArTwo")
+    assertEquals("ArTwo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -397,7 +396,7 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     channel.assertEmpty()
 
@@ -423,7 +422,7 @@ class WatcherTest {
           }
     }
 
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // Write "Artoo" out of band. Only one response was enqueued, so a refetch that went to the
     // network would fail instead of reading the cache.
@@ -433,7 +432,7 @@ class WatcherTest {
         publish = true,
     )
 
-    assertEquals(channel.awaitElement()?.hero?.name, "Artoo")
+    assertEquals("Artoo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -473,7 +472,7 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     assertEquals(1, executions)
 
@@ -501,7 +500,7 @@ class WatcherTest {
           }
     }
 
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // Enqueue 2 responses.
     // - The first one will be for the query just below and contains "Artoo"
@@ -516,7 +515,7 @@ class WatcherTest {
     val response = apolloClient.query(episodeHeroNameQuery)
         .fetchPolicy(FetchPolicy.NetworkOnly)
         .execute()
-    assertEquals(response.data?.hero?.name, "Artoo")
+    assertEquals("Artoo", response.data?.hero?.name)
 
     // The watcher should refetch from the network and now see "ArTwo"
     assertEquals("ArTwo", channel.awaitElement()?.hero?.name)
@@ -600,13 +599,13 @@ class WatcherTest {
     }
 
     // Because subscribe is called from a background thread, give some time to be effective
-    delay(500)
+    delay(500.milliseconds)
 
     // Another newer call gets updated information with "R2-D2"
     apolloClient.enqueueTestResponse(query, episodeHeroNameData)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -659,13 +658,13 @@ class WatcherTest {
 
     // Cache miss is emitted first (null data)
     assertNull(channel.awaitElement())
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // Another newer call gets updated information with "Artoo"
     apolloClient.enqueueTestResponse(query, episodeHeroNameChangedData)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
-    assertEquals(channel.awaitElement()?.hero?.name, "Artoo")
+    assertEquals("Artoo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -696,17 +695,17 @@ class WatcherTest {
           }
     }
     // 1. Value from the cache
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // 2. Value from the network
-    assertEquals(channel.awaitElement()?.hero?.name, "Artoo")
+    assertEquals("Artoo", channel.awaitElement()?.hero?.name)
 
     // Another newer call updates the cache with "ArTwo"
     apolloClient.enqueueTestResponse(query, episodeHeroNameChangedTwoData)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
     // 3. Value from watching the cache
-    assertEquals(channel.awaitElement()?.hero?.name, "ArTwo")
+    assertEquals("ArTwo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -733,17 +732,17 @@ class WatcherTest {
           }
     }
     // 1. Value from the cache
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // 2. Value from the network
-    assertEquals(channel.awaitElement(5000)?.hero?.name, "Artoo")
+    assertEquals("Artoo", channel.awaitElement(5000)?.hero?.name)
 
     // Another newer call updates the cache with "ArTwo"
     apolloClient.enqueueTestResponse(query, episodeHeroNameChangedTwoData)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
     // 3. Value from watching the cache
-    assertEquals(channel.awaitElement()?.hero?.name, "ArTwo")
+    assertEquals("ArTwo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -768,14 +767,14 @@ class WatcherTest {
     // 0. Cache miss (null data)
     assertNull(channel.awaitElement())
     // 1. Value from the network
-    assertEquals(channel.awaitElement(5000)?.hero?.name, "Artoo")
+    assertEquals("Artoo", channel.awaitElement(5000)?.hero?.name)
 
     // Another newer call updates the cache with "ArTwo"
     apolloClient.enqueueTestResponse(query, episodeHeroNameChangedTwoData)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
     // 2. Value from watching the cache
-    assertEquals(channel.awaitElement()?.hero?.name, "ArTwo")
+    assertEquals("ArTwo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -798,7 +797,7 @@ class WatcherTest {
     // Prepare next call to be a network error
     mockServer.enqueue(MockResponse.Builder().delayMillis(Long.MAX_VALUE).build())
 
-    withTimeout(500) {
+    withTimeout(500.milliseconds) {
       // make sure we get the cache only result
       val response = apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch().first()
       assertEquals("R2-D2", response.data?.hero?.name)
@@ -831,7 +830,7 @@ class WatcherTest {
           }
     }
     // 1. Value from the cache
-    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+    assertEquals("R2-D2", channel.awaitElement()?.hero?.name)
 
     // 2. Exception from the network (null data)
     assertNull(channel.awaitElement())
@@ -842,7 +841,7 @@ class WatcherTest {
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
     // 3. Value from watching the cache
-    assertEquals(channel.awaitElement()?.hero?.name, "ArTwo")
+    assertEquals("ArTwo", channel.awaitElement()?.hero?.name)
 
     job.cancel()
   }
@@ -874,7 +873,7 @@ class WatcherTest {
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
     // Value from watching the cache
-    assertEquals(channel.awaitElement().data?.hero?.name, "ArTwo")
+    assertEquals("ArTwo", channel.awaitElement().data?.hero?.name)
 
     job.cancel()
   }
@@ -902,20 +901,13 @@ class WatcherTest {
   }
 }
 
-internal suspend fun <D> Channel<D>.assertCount(count: Int) {
-  repeat(count) {
-    awaitElement()
-  }
-  assertEmpty()
-}
-
-internal suspend fun <T> Channel<T>.awaitElement(timeoutMillis: Long = 30000) = withTimeout(timeoutMillis) {
+internal suspend fun <T> Channel<T>.awaitElement(timeoutMillis: Long = 30000) = withTimeout(timeoutMillis.milliseconds) {
   receive()
 }
 
-internal suspend fun <T> Channel<T>.assertEmpty(timeoutMillis: Long = 300): Unit {
+internal suspend fun <T> Channel<T>.assertEmpty(timeoutMillis: Long = 300) {
   try {
-    withTimeout(timeoutMillis) {
+    withTimeout(timeoutMillis.milliseconds) {
       receive()
     }
     error("An item was unexpectedly received")

--- a/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
@@ -2,10 +2,14 @@ package test
 
 import app.cash.turbine.test
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.ApolloResponse
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.composeJsonResponse
 import com.apollographql.apollo.exception.ApolloNetworkException
 import com.apollographql.apollo.exception.CacheMissException
+import com.apollographql.apollo.interceptor.ApolloInterceptor
+import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestNetworkError
 import com.apollographql.apollo.testing.enqueueTestResponse
@@ -33,6 +37,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -371,6 +376,109 @@ class WatcherTest {
     assertEquals(channel.awaitElement()?.hero?.name, "ArTwo")
 
     job.cancel()
+  }
+
+  /**
+   * The initial fetch writes its response to the cache and publishes the changed keys. The watcher
+   * subscribes only once those responses are in, so it must not react to its own write.
+   */
+  @Test
+  fun initialFetchDoesNotTriggerTheWatcher() = runTest(before = { setUp() }) {
+    val query = EpisodeHeroNameWithIdQuery(Episode.EMPIRE)
+    val channel = Channel<EpisodeHeroNameWithIdQuery.Data?>()
+
+    // The cache starts empty, so the initial fetch does change it
+    apolloClient.enqueueTestResponse(query, episodeHeroNameWithIdData)
+    val job = launch {
+      apolloClient.query(query).watch().collect {
+        channel.send(it.data)
+      }
+    }
+
+    // Cache miss is emitted first (null data)
+    assertNull(channel.awaitElement())
+    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+
+    channel.assertEmpty()
+
+    job.cancel()
+  }
+
+  /**
+   * The initial responses use the fetch policy while the refetches use the refetch policy, including
+   * when the two disagree: a NetworkOnly watch still refetches from the cache under the default
+   * CacheOnly refetch policy rather than going back to the network.
+   */
+  @Test
+  fun refetchUsesTheRefetchPolicyRatherThanTheFetchPolicy() = runTest(before = { setUp() }) {
+    val query = EpisodeHeroNameWithIdQuery(Episode.EMPIRE)
+    val channel = Channel<EpisodeHeroNameWithIdQuery.Data?>()
+
+    apolloClient.enqueueTestResponse(query, episodeHeroNameWithIdData)
+    val job = launch {
+      apolloClient.query(query)
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .watch().collect {
+            channel.send(it.data)
+          }
+    }
+
+    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+
+    // Write "Artoo" out of band. Only one response was enqueued, so a refetch that went to the
+    // network would fail instead of reading the cache.
+    cacheManager.writeOperation(
+        query,
+        EpisodeHeroNameWithIdQuery.Data(EpisodeHeroNameWithIdQuery.Hero("Droid", "2001", "Artoo")),
+        publish = true,
+    )
+
+    assertEquals(channel.awaitElement()?.hero?.name, "Artoo")
+
+    job.cancel()
+  }
+
+  /**
+   * The initial responses and the cache subscription come from a single execution of the interceptor
+   * chain, so interceptors sitting ahead of the cache run once rather than once per execution.
+   */
+  @Test
+  fun watchExecutesTheInterceptorChainOnce() = runTest {
+    var executions = 0
+    val countingInterceptor = object : ApolloInterceptor {
+      override fun <D : Operation.Data> intercept(
+          request: ApolloRequest<D>,
+          chain: ApolloInterceptorChain,
+      ): Flow<ApolloResponse<D>> {
+        executions++
+        return chain.proceed(request)
+      }
+    }
+    val cacheManager =
+      CacheManager(MemoryCacheFactory(), cacheKeyGenerator = IdCacheKeyGenerator(), cacheResolver = IdCacheResolver())
+    val apolloClient = ApolloClient.Builder()
+        .networkTransport(QueueTestNetworkTransport())
+        .cacheManager(cacheManager)
+        .addInterceptor(countingInterceptor)
+        .build()
+
+    val query = EpisodeHeroNameWithIdQuery(Episode.EMPIRE)
+    val channel = Channel<EpisodeHeroNameWithIdQuery.Data?>()
+    apolloClient.enqueueTestResponse(query, episodeHeroNameWithIdData)
+    val job = launch {
+      apolloClient.query(query).watch().collect {
+        channel.send(it.data)
+      }
+    }
+
+    // Cache miss is emitted first (null data)
+    assertNull(channel.awaitElement())
+    assertEquals(channel.awaitElement()?.hero?.name, "R2-D2")
+
+    assertEquals(1, executions)
+
+    job.cancel()
+    apolloClient.close()
   }
 
   /**


### PR DESCRIPTION
watch() executed the operation twice: once through toFlow() for the initial
responses, then again through copy().watchInternal() to subscribe to the
cache. The last initial response was withheld until that second execution had
subscribed, so callers waited on a flow teardown, a fresh
channelFlow/withContext dispatch, and a re-run of every interceptor ahead of
the cache before receiving data that was already in hand.

Move the initial fetch into WatcherInterceptor. It proceeds once with the
fetch policy, subscribes, releases the withheld response, and then proceeds
per cache change with the refetch policy - all from a single execution of the
interceptor chain. What the withheld response now waits on is a SharedFlow
subscription and nothing else.

The synchronisation point of https://github.com/apollographql/apollo-kotlin/pull/3853 is preserved:
the response is still released only after the subscription is established, so
modifying the store on receiving it is still observed.

Subscribing *before* the initial fetch was tried first and is not viable: the
watcher then sees its own initial write publish and refetches, which breaks 13
tests with duplicated emissions and shifted sequences. The ordering here is
load-bearing, and the cost it used to carry came from the second chain
execution rather than from the ordering itself.

watch(data) keeps its existing behaviour through fetchInitialResponses=false:
no initial request, fetch policy used throughout, sentinel still emitted for
the public overload to filter.