### PR TITLE
Enable parallel sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version (unreleased)
 
+- Enable parallel sync for Tooling API clients (#380)
+
 PUT_CHANGELOG_HERE
 
 # v1.0.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,6 @@ android.useAndroidX=true
 
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.tooling.parallel=true
 
 kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Gradle 9.4 added `org.gradle.tooling.parallel`, which lets Tooling API clients build project models in parallel rather than one at a time. IDE sync is the consumer that matters here.

The wrapper is already on Gradle 9.5.0, and the build already runs with `org.gradle.parallel=true`.