### PR TITLE
Merge headers in CacheHeadersContext

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
@@ -141,8 +141,8 @@ internal class DefaultCacheManager(
       customScalarAdapters: CustomScalarAdapters,
       cacheHeaders: CacheHeaders,
   ): ApolloResponse<D> {
-    val cacheMissesAsException = cacheHeaders.headerValue(ApolloCacheHeaders.CACHE_MISSES_AS_EXCEPTION) == "true"
-    val serverErrorsAsException = cacheHeaders.headerValue(ApolloCacheHeaders.SERVER_ERRORS_AS_EXCEPTION) == "true"
+    val cacheMissesAsException = (cacheHeaders.headerValue(ApolloCacheHeaders.CACHE_MISSES_AS_EXCEPTION) ?: "true") == "true"
+    val serverErrorsAsException = (cacheHeaders.headerValue(ApolloCacheHeaders.SERVER_ERRORS_AS_EXCEPTION) ?: "true") == "true"
     val variables = operation.variables(customScalarAdapters, true)
     val batchReaderData =
       try {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/cacheHeaders.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/cacheHeaders.kt
@@ -15,25 +15,20 @@ internal class CacheHeadersContext(val value: CacheHeaders) : ExecutionContext.E
   override val key: ExecutionContext.Key<*>
     get() = Key
 
+  /**
+   * Merge the [CacheHeaders] instead of letting the right element replace the right element.
+   */
+  override fun <R> fold(initial: R, operation: (R, ExecutionContext.Element) -> R): R {
+    val existing = (initial as? ExecutionContext)?.get(Key)
+    val element = if (existing != null) CacheHeadersContext(existing.value + value) else this
+    return operation(initial, element)
+  }
+
   companion object Key : ExecutionContext.Key<CacheHeadersContext>
 }
 
 internal val ExecutionOptions.cacheHeaders: CacheHeaders
-  get() = (executionContext[CacheHeadersContext]?.value ?: CacheHeaders.NONE).withDefaultValues
-
-private val CacheHeaders.withDefaultValues: CacheHeaders
-  get() = newBuilder()
-      .apply {
-        // Apply values for ExecutionOptions.cacheMissesAsException and ExecutionOptions.serverErrorsAsException
-        // which are true by default contrary to other flags.
-        if (!hasHeader(ApolloCacheHeaders.CACHE_MISSES_AS_EXCEPTION)) {
-          addHeader(ApolloCacheHeaders.CACHE_MISSES_AS_EXCEPTION, "true")
-        }
-        if (!hasHeader(ApolloCacheHeaders.SERVER_ERRORS_AS_EXCEPTION)) {
-          addHeader(ApolloCacheHeaders.SERVER_ERRORS_AS_EXCEPTION, "true")
-        }
-      }
-      .build()
+  get() = (executionContext[CacheHeadersContext]?.value ?: CacheHeaders.NONE)
 
 fun <D : Operation.Data> ApolloResponse.Builder<D>.cacheHeaders(cacheHeaders: CacheHeaders) =
   addExecutionContext(CacheHeadersContext(cacheHeaders))

--- a/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/noExceptionsHeaders.kt
+++ b/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/noExceptionsHeaders.kt
@@ -1,0 +1,9 @@
+package com.apollographql.cache.normalized.testing
+
+import com.apollographql.cache.normalized.api.ApolloCacheHeaders
+import com.apollographql.cache.normalized.api.CacheHeaders
+
+val noExceptionsHeaders = CacheHeaders.Builder()
+    .addHeader(ApolloCacheHeaders.CACHE_MISSES_AS_EXCEPTION, "false")
+    .addHeader(ApolloCacheHeaders.SERVER_ERRORS_AS_EXCEPTION, "false")
+    .build()

--- a/tests/cache-options/build.gradle.kts
+++ b/tests/cache-options/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
         implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
+        implementation(libs.turbine)
       }
     }
 

--- a/tests/cache-options/src/commonMain/graphql/operation.graphql
+++ b/tests/cache-options/src/commonMain/graphql/operation.graphql
@@ -125,3 +125,18 @@ fragment UserFields on User {
     lastName
   }
 }
+
+query GetCar($carId:String!) {
+  car(carId: $carId) {
+    id
+    color
+    doors
+  }
+}
+
+query GetCarColor($carId:String!) {
+  car(carId: $carId) {
+    id
+    color
+  }
+}

--- a/tests/cache-options/src/commonMain/graphql/schema.graphqls
+++ b/tests/cache-options/src/commonMain/graphql/schema.graphqls
@@ -6,6 +6,7 @@ type Query {
   user(category: Category!): User
   someInt: Int
   someInt2: Int
+  car(carId: String!): Car
 }
 
 type User {
@@ -38,3 +39,10 @@ type EmployeeInfo {
 
 scalar Category
 scalar Json
+
+
+type Car {
+  id: String!
+  color: String!
+  doors: Int
+}

--- a/tests/cache-options/src/commonTest/kotlin/test/CacheOptionsTest.kt
+++ b/tests/cache-options/src/commonTest/kotlin/test/CacheOptionsTest.kt
@@ -1,5 +1,6 @@
 package test
 
+import app.cash.turbine.test
 import com.apollographql.apollo.ApolloCall
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
@@ -14,13 +15,18 @@ import com.apollographql.cache.normalized.api.FieldPolicyCacheResolver
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.apolloStore
 import com.apollographql.cache.normalized.cacheManager
+import com.apollographql.cache.normalized.errorsReplaceCachedValues
 import com.apollographql.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.maxStale
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.memoryCacheOnly
 import com.apollographql.cache.normalized.options.cacheMissesAsException
 import com.apollographql.cache.normalized.options.serverErrorsAsException
+import com.apollographql.cache.normalized.storeReceivedDate
 import com.apollographql.cache.normalized.testing.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.testing.assertErrorsEquals
 import com.apollographql.cache.normalized.testing.runTest
+import com.apollographql.cache.normalized.watch
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import kotlinx.coroutines.flow.Flow
@@ -34,6 +40,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.days
 
 class CacheOptionsTest {
   private lateinit var mockServer: MockServer
@@ -986,6 +993,86 @@ class CacheOptionsTest {
     assertEquals(response.errors?.size, 1)
   }
 
+  // Taken from https://github.com/apollographql/apollo-kotlin-normalized-cache/issues/374
+  @Test
+  fun memoryCacheOnlyIsPropagated() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueueString(
+        // language=JSON
+        """
+          {
+            "data": {
+              "car": {
+                "__typename": "Car",
+                "id": "1",
+                "color": "Red",
+                "doors": null
+              }
+            },
+            "errors": [
+              {
+                "message": "Doors does not exist",
+                "type": "DoorsNotFoundError",
+                "path": ["car", "doors"],
+                "extensions": {
+                  "type": "DoorsNotFoundError"
+                },
+                "nonStandardFields": {
+                  "type": "DoorsNotFoundError"
+                }
+              }
+            ]
+          }
+          """,
+    )
+    mockServer.enqueueString(
+        // language=JSON
+        """
+          {
+            "data": {
+              "car": {
+                "__typename": "Car",
+                "id": "1",
+                "color": "Blue"
+              }
+            }
+          }
+          """,
+    )
+
+    ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .storeReceivedDate(true)
+        .maxStale(14.days)
+        .cacheMissesAsException(true)
+        .serverErrorsAsException(false)
+        .errorsReplaceCachedValues(true)
+        .cacheManager(memoryThenSqlCacheManager)
+        .build()
+        .use { apolloClient ->
+          val networkRequest = apolloClient.query(GetCarQuery(carId = "1"))
+              .fetchPolicy(FetchPolicy.NetworkOnly)
+              .memoryCacheOnly(true)
+              .watch()
+
+          val updateColorRequest = apolloClient.query(GetCarColorQuery(carId = "1"))
+              .fetchPolicy(FetchPolicy.NetworkOnly)
+
+          networkRequest.test {
+            val item1 = awaitItem()
+            assertIs<ApolloResponse<GetCarQuery.Data>>(item1)
+            assertEquals("Red", item1.data?.car?.color)
+            // When
+            val updatedColorResponse = updateColorRequest.execute()
+            assertIs<ApolloResponse<GetCarColorQuery.Data>>(updatedColorResponse)
+            assertEquals("Blue", updatedColorResponse.data?.car?.color)
+            // Then
+            val item2 = awaitItem()
+            assertIs<ApolloResponse<GetCarQuery.Data>>(item2)
+            assertEquals("Blue", item2.data?.car?.color)
+            cancelAndIgnoreRemainingEvents()
+          }
+        }
+  }
 }
 
 private fun <D : Operation.Data> ApolloCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> {

--- a/tests/normalized-cache/src/commonTest/kotlin/declarativecache/DeclarativeCacheTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/declarativecache/DeclarativeCacheTest.kt
@@ -10,6 +10,7 @@ import com.apollographql.cache.normalized.api.ResolverContext
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.testing.assertErrorsEquals
+import com.apollographql.cache.normalized.testing.noExceptionsHeaders
 import com.apollographql.cache.normalized.testing.runTest
 import declarativecache.GetAuthorQuery
 import declarativecache.GetBookQuery
@@ -219,7 +220,7 @@ class DeclarativeCacheTest {
     // We query for 2 books but get only 1 from the backend
     cacheManager.writeOperation(GetBooksQuery(listOf("42", "43")), GetBooksQuery.Data(listOf(GetBooksQuery.Book(__typename = "Book", title = "Promo", isbn = "42"))))
 
-    val booksCacheResponse = cacheManager.readOperation(GetBooksQuery(listOf("42", "44")))
+    val booksCacheResponse = cacheManager.readOperation(GetBooksQuery(listOf("42", "44")), cacheHeaders = noExceptionsHeaders)
     assertNull(booksCacheResponse.data)
     assertErrorsEquals(
         listOf(

--- a/tests/pagination/src/commonTest/kotlin/ConnectionPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/ConnectionPaginationTest.kt
@@ -13,6 +13,7 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.testing.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.noExceptionsHeaders
 import com.apollographql.cache.normalized.testing.runTest
 import pagination.connection.UsersQuery
 import pagination.connection.cache.Cache
@@ -413,7 +414,7 @@ class ConnectionPaginationTest {
         data = UsersQuery.Data { users = null },
         errors = listOf(Error.Builder("An error occurred.").path(listOf("users")).build()),
     )
-    val responseFromStore = cacheManager.readOperation(query)
+    val responseFromStore = cacheManager.readOperation(query, cacheHeaders = noExceptionsHeaders)
     assertEquals(UsersQuery.Data { users = null }, responseFromStore.data)
     assertEquals(1, responseFromStore.errors?.size)
     assertEquals("An error occurred.", responseFromStore.errors?.firstOrNull()?.message)

--- a/tests/pagination/src/commonTest/kotlin/ConnectionWithUnionPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/ConnectionWithUnionPaginationTest.kt
@@ -13,6 +13,7 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.testing.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.noExceptionsHeaders
 import com.apollographql.cache.normalized.testing.runTest
 import pagination.connectionWithUnion.UsersQuery
 import pagination.connectionWithUnion.cache.Cache
@@ -439,7 +440,7 @@ class ConnectionWithUnionPaginationTest {
         data = UsersQuery.Data { someField = buildSomeType { users = null } },
         errors = listOf(Error.Builder("An error occurred.").path(listOf("someField", "users")).build())
     )
-    val responseFromStore = cacheManager.readOperation(query)
+    val responseFromStore = cacheManager.readOperation(query, cacheHeaders = noExceptionsHeaders)
     assertEquals(UsersQuery.Data { someField = buildSomeType { users = null } }, responseFromStore.data)
     assertEquals(1, responseFromStore.errors?.size)
     assertEquals("An error occurred.", responseFromStore.errors?.firstOrNull()?.message)

--- a/tests/store-errors/src/commonTest/kotlin/test/StoreErrorsTest.kt
+++ b/tests/store-errors/src/commonTest/kotlin/test/StoreErrorsTest.kt
@@ -26,6 +26,7 @@ import com.apollographql.cache.normalized.options.cacheMissesAsException
 import com.apollographql.cache.normalized.options.serverErrorsAsException
 import com.apollographql.cache.normalized.testing.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.testing.assertErrorsEquals
+import com.apollographql.cache.normalized.testing.noExceptionsHeaders
 import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
@@ -769,7 +770,7 @@ class StoreErrorsTest {
             Error.Builder("'nickName' can't be reached").path(listOf("me", "nickName")).build(),
         ),
     )
-    val responseFromCache = cacheManager.readOperation(MeWithNickNameQuery())
+    val responseFromCache = cacheManager.readOperation(MeWithNickNameQuery(), cacheHeaders = noExceptionsHeaders)
     assertEquals(
         MeWithNickNameQuery.Data(
             MeWithNickNameQuery.Me(
@@ -904,4 +905,3 @@ val PartialCacheOnlyInterceptor = object : ApolloInterceptor {
     )
   }
 }
-


### PR DESCRIPTION
Merge headers in `CacheHeadersContext`.

Also handle `CACHE_MISSES_AS_EXCEPTION` and `SERVER_ERRORS_AS_EXCEPTION` default values more sensibly.

Fixes #374 

Note: this is actually a behavior change when using `CacheManager` directly (as opposed to using `ApolloStore`), as some of our tests do. Previously:
- `CACHE_MISSES_AS_EXCEPTION` and `SERVER_ERRORS_AS_EXCEPTION` would default to `false` when using `CacheManager` directly but default to `true` when using higher-level APIs.
- With this PR they default to `true` consistently.

