### PR TITLE
Fix: apply known key abbreviations to inner metadata keys

### DIFF
--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordSerializer.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordSerializer.kt
@@ -21,7 +21,7 @@ internal object RecordSerializer {
     buffer._writeInt(record.metadata.size)
     for ((k, v) in record.metadata) {
       buffer.writeString(k.shortenCacheKey())
-      buffer.writeMap(v.mapKeys { (metadataKey, _) -> knownMetadataKeys[metadataKey] ?: metadataKey })
+      buffer.writeMetadataMap(v)
     }
     return buffer.readByteArray()
   }
@@ -33,7 +33,7 @@ internal object RecordSerializer {
     val metadata = HashMap<String, Map<String, ApolloJsonElement>>(metadataSize).apply {
       repeat(metadataSize) {
         val k = buffer.readString().expandCacheKey()
-        val v = buffer.readMap().mapKeys { (metadataKey, _) -> knownMetadataKeysInverted[metadataKey] ?: metadataKey }
+        val v = buffer.readMetadataMap()
         put(k, v)
       }
     }
@@ -131,6 +131,38 @@ internal object RecordSerializer {
     return HashMap<String, RecordValue>(size).apply {
       repeat(size) {
         put(readString(), readAny())
+      }
+    }
+  }
+
+  // Encode certain known metadata keys as single byte strings to save space
+  private fun Buffer.writeMetadataMap(value: Map<String, RecordValue>) {
+    _writeInt(value.size)
+    for ((k, v) in value) {
+      writeString(
+          when (k) {
+            ApolloCacheHeaders.RECEIVED_DATE -> "0"
+            ApolloCacheHeaders.EXPIRATION_DATE -> "1"
+            else -> k
+          }
+      )
+      writeAny(v)
+    }
+  }
+
+  private fun Buffer.readMetadataMap(): Map<String, RecordValue> {
+    val size = _readInt()
+    return HashMap<String, RecordValue>(size).apply {
+      repeat(size) {
+        val key = readString()
+        put(
+            when (key) {
+              "0" -> ApolloCacheHeaders.RECEIVED_DATE
+              "1" -> ApolloCacheHeaders.EXPIRATION_DATE
+              else -> key
+            },
+            readAny()
+        )
       }
     }
   }
@@ -313,13 +345,6 @@ internal object RecordSerializer {
   private const val MAP_EMPTY = FIRST + 18
   private const val CACHE_KEY = FIRST + 19
   private const val ERROR = FIRST + 20
-
-  // Encode certain known metadata keys as single byte strings to save space
-  private val knownMetadataKeys = mapOf(
-      ApolloCacheHeaders.RECEIVED_DATE to "0",
-      ApolloCacheHeaders.EXPIRATION_DATE to "1",
-  )
-  private val knownMetadataKeysInverted = knownMetadataKeys.entries.associate { (k, v) -> v to k }
 
   private val mutationPrefixLong = CacheKey.MUTATION_ROOT.key + "."
   private val subscriptionPrefixLong = CacheKey.SUBSCRIPTION_ROOT.key + "."

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordSerializer.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordSerializer.kt
@@ -19,9 +19,9 @@ internal object RecordSerializer {
     val buffer = Buffer()
     buffer.writeMap(record.fields)
     buffer._writeInt(record.metadata.size)
-    for ((k, v) in record.metadata.mapKeys { (k, _) -> knownMetadataKeys[k] ?: k }) {
+    for ((k, v) in record.metadata) {
       buffer.writeString(k.shortenCacheKey())
-      buffer.writeMap(v)
+      buffer.writeMap(v.mapKeys { (metadataKey, _) -> knownMetadataKeys[metadataKey] ?: metadataKey })
     }
     return buffer.readByteArray()
   }
@@ -33,10 +33,10 @@ internal object RecordSerializer {
     val metadata = HashMap<String, Map<String, ApolloJsonElement>>(metadataSize).apply {
       repeat(metadataSize) {
         val k = buffer.readString().expandCacheKey()
-        val v = buffer.readMap()
+        val v = buffer.readMap().mapKeys { (metadataKey, _) -> knownMetadataKeysInverted[metadataKey] ?: metadataKey }
         put(k, v)
       }
-    }.mapKeys { (k, _) -> knownMetadataKeysInverted[k] ?: k }
+    }
     return Record(
         key = CacheKey(key),
         fields = fields,

--- a/normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheTest.kt
+++ b/normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheTest.kt
@@ -142,6 +142,36 @@ class SqlNormalizedCacheTest {
   }
 
   @Test
+  fun testMetadataKnownKeyAbbreviationOnlyAppliesToInnerMetadataKeys() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val fieldNameThatMatchesKnownMetadataKey = ApolloCacheHeaders.RECEIVED_DATE
+    val record = Record(
+        key = STANDARD_KEY,
+        fields = mapOf(
+            fieldNameThatMatchesKnownMetadataKey to "value",
+            "0" to "otherValue",
+        ),
+        metadata = mapOf(
+            fieldNameThatMatchesKnownMetadataKey to mapOf(
+                ApolloCacheHeaders.RECEIVED_DATE to 1L,
+                ApolloCacheHeaders.EXPIRATION_DATE to 2L,
+            ),
+            "0" to mapOf(
+                ApolloCacheHeaders.RECEIVED_DATE to 3L,
+            ),
+        ),
+    )
+
+    cache.merge(
+        record = record,
+        cacheHeaders = CacheHeaders.NONE,
+        recordMerger = DefaultRecordMerger,
+    )
+
+    val loaded = requireNotNull(cache.loadRecord(STANDARD_KEY, CacheHeaders.NONE))
+    assertEquals(record.metadata, loaded.metadata)
+  }
+
+  @Test
   fun testRecordMerge_noOldRecord() = runTest(before = { setUp() }, after = { tearDown() }) {
     val changedKeys = cache.merge(
         record = Record(


### PR DESCRIPTION
Some known metadata keys can be abbreviated to save space, but this was done incorrectly (was done on the field keys, not the field's map value's keys). This PR fixes that and also avoids using `.map{}` which allocates a new map.