### PR TITLE
perf(cache): Reduce allocations on the normalize, read, and SQLite paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - [Improvement] Derive the keys a watcher matches cache changes against lazily, keeping the re-normalization of the whole response off the path that delivers the initial responses of `watch` (#378)
 - [Improvement] Reduce allocations when deriving a watcher's dependent keys and matching them against a cache change (#378)
 - Enable parallel sync for Tooling API clients (#380)
+- [Improvement] Reduce allocations when normalizing and when reading from the cache: stop rebuilding a field that is already the result of merging its group, memoize field keys, and intern the response paths the batch reader keys its data by (#383)
+- [Improvement] Reduce allocations and copies in the SQLite cache: stream records straight out of the query buffer, and slice large records instead of boxing them byte by byte (#383)
 
 PUT_CHANGELOG_HERE
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enable parallel sync for Tooling API clients (#380)
 - [Improvement] Reduce allocations when normalizing and when reading from the cache: stop rebuilding a field that is already the result of merging its group, memoize field keys, and intern the response paths the batch reader keys its data by (#383)
 - [Improvement] Reduce allocations and copies in the SQLite cache: stream records straight out of the query buffer, and slice large records instead of boxing them byte by byte (#383)
+- [Improvement] Don't build the max age field path when the `MaxAgeProvider` is a `GlobalMaxAgeProvider`, which ignores it (#383)
 
 PUT_CHANGELOG_HERE
 

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
@@ -107,7 +107,7 @@ class SqlNormalizedCache internal constructor(
 
   override fun sizeOfRecord(record: Record): Int {
     val keySize = record.key.key.length
-    return keySize + RecordSerializer.serialize(record).size
+    return keySize + RecordSerializer.serializedSize(record)
   }
 
   override suspend fun size(): Long {
@@ -169,20 +169,24 @@ class SqlNormalizedCache internal constructor(
       val expirationDate = cacheHeaders.headerValue(ApolloCacheHeaders.EXPIRATION_DATE)
       recordDatabase.transaction {
         val existingRecords = selectRecords(records.map { it.key }).associateBy { it.key }
-        records.flatMap { record ->
-          val record = record.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
+        // Accumulated in one pass: `flatMap {}.toSet()` would materialize every changed field key of
+        // every record in a list before building the set that is actually returned.
+        val changed = mutableSetOf<String>()
+        for (incoming in records) {
+          val record = incoming.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
           val existingRecord = existingRecords[record.key]
           if (existingRecord == null) {
             recordDatabase.insertOrUpdateRecord(record, deleteFirst = false)
-            record.fieldKeys()
+            changed.addAll(record.fieldKeys())
           } else {
             val (mergedRecord, changedKeys) = recordMerger.merge(RecordMergerContext(existing = existingRecord, incoming = record, cacheHeaders = cacheHeaders))
             if (mergedRecord.isNotEmpty() && mergedRecord != existingRecord) {
               recordDatabase.insertOrUpdateRecord(mergedRecord)
             }
-            changedKeys
+            changed.addAll(changedKeys)
           }
-        }.toSet()
+        }
+        changed
       }
     }
   }

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
@@ -169,8 +169,6 @@ class SqlNormalizedCache internal constructor(
       val expirationDate = cacheHeaders.headerValue(ApolloCacheHeaders.EXPIRATION_DATE)
       recordDatabase.transaction {
         val existingRecords = selectRecords(records.map { it.key }).associateBy { it.key }
-        // Accumulated in one pass: `flatMap {}.toSet()` would materialize every changed field key of
-        // every record in a list before building the set that is actually returned.
         val changed = mutableSetOf<String>()
         for (incoming in records) {
           val record = incoming.withDates(receivedDate = receivedDate, expirationDate = expirationDate)

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordDatabase.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordDatabase.kt
@@ -59,13 +59,13 @@ internal class RecordDatabase(
     for (row in rows) {
       val key = row.key
       if (key != lastKey && lastKey != null) {
-        records.add(RecordSerializer.deserialize(lastKey, buffer.readByteArray()))
+        records.add(buffer.readRecord(lastKey))
       }
       buffer.write(row.record)
       lastKey = key
     }
     if (lastKey != null) {
-      records.add(RecordSerializer.deserialize(lastKey, buffer.readByteArray()))
+      records.add(buffer.readRecord(lastKey))
     }
     return records
   }
@@ -80,7 +80,7 @@ internal class RecordDatabase(
         for (row in rowPage) {
           val key = row.key
           if (key != lastKey && lastKey != null) {
-            emit(RecordSerializer.deserialize(lastKey, buffer.readByteArray()))
+            emit(buffer.readRecord(lastKey))
           }
           buffer.write(row.record)
           lastKey = key
@@ -88,12 +88,28 @@ internal class RecordDatabase(
 
         if (rowPage.size < pageSize) {
           if (lastKey != null) {
-            emit(RecordSerializer.deserialize(lastKey, buffer.readByteArray()))
+            emit(buffer.readRecord(lastKey))
           }
           break
         }
         offset += pageSize
       }
+    }
+  }
+
+  /**
+   * Deserializes the record accumulated in this buffer and leaves the buffer empty, ready for the
+   * next one.
+   *
+   * [RecordSerializer.deserialize] consumes exactly the bytes it wrote, but the buffer is reused
+   * across records, so it is cleared explicitly: were a record ever to deserialize short, the
+   * leftovers would corrupt every record read after it.
+   */
+  private fun Buffer.readRecord(key: String): Record {
+    return try {
+      RecordSerializer.deserialize(key, this)
+    } finally {
+      clear()
     }
   }
 
@@ -115,14 +131,20 @@ internal class RecordDatabase(
       return
     }
 
-    val chunks = recordBytes.asIterable().chunked(BLOB_CHUNK_SIZE)
-    for ((index, chunk) in chunks.withIndex()) {
+    // Slice the array directly: `asIterable().chunked()` would box every byte of the record into a
+    // `List<Byte>` and materialize all the chunks before the first insert, only to unbox them again.
+    var index = 0
+    var offset = 0
+    while (offset < recordBytes.size) {
+      val end = minOf(offset + BLOB_CHUNK_SIZE, recordBytes.size)
       recordQueries.insertOrUpdateRecord(
           key = record.key.key,
           chunk_index = index.toLong(),
-          record = chunk.toByteArray(),
+          record = recordBytes.copyOfRange(offset, end),
           updated_date = updatedDate,
       )
+      index++
+      offset = end
     }
   }
 

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordSerializer.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordSerializer.kt
@@ -22,8 +22,7 @@ internal object RecordSerializer {
   }
 
   /**
-   * The number of bytes [serialize] would return for [record], without allocating the [ByteArray] to
-   * hold them.
+   * The number of bytes [serialize] would return for [record].
    */
   fun serializedSize(record: Record): Int {
     val buffer = Buffer()
@@ -42,15 +41,11 @@ internal object RecordSerializer {
 
   /**
    * Reads a record from [buffer], consuming exactly the bytes [serialize] wrote for it.
-   *
-   * Taking the buffer rather than a [ByteArray] lets the caller stream rows straight into the
-   * deserializer: going through `readByteArray()` copies the bytes out of the buffer only for this
-   * method to copy them back into another one.
    */
   fun deserialize(key: String, buffer: Buffer): Record {
     val fields = buffer.readMap()
     val metadataSize = buffer._readInt()
-    val metadata = HashMap<String, Map<String, ApolloJsonElement>>(mapCapacity(metadataSize)).apply {
+    val metadata = HashMap<String, Map<String, ApolloJsonElement>>(mapCapacity(metadataSize), LOAD_FACTOR).apply {
       repeat(metadataSize) {
         val k = buffer.readString().expandCacheKey()
         val v = buffer.readMetadataMap()
@@ -67,8 +62,7 @@ internal object RecordSerializer {
 
   /**
    * The capacity to give a [HashMap] that is about to receive [size] entries, so that it does not
-   * rehash on the way there. [HashMap] grows once it is [LOAD_FACTOR] full, so sizing it to [size]
-   * exactly rehashes every map of more than 3 entries.
+   * rehash on the way there.
    */
   private fun mapCapacity(size: Int): Int = (size / LOAD_FACTOR).toInt() + 1
 
@@ -155,7 +149,7 @@ internal object RecordSerializer {
 
   private fun Buffer.readMap(): Map<String, RecordValue> {
     val size = _readInt()
-    return HashMap<String, RecordValue>(mapCapacity(size)).apply {
+    return HashMap<String, RecordValue>(mapCapacity(size), LOAD_FACTOR).apply {
       repeat(size) {
         put(readString(), readAny())
       }
@@ -179,7 +173,7 @@ internal object RecordSerializer {
 
   private fun Buffer.readMetadataMap(): Map<String, RecordValue> {
     val size = _readInt()
-    return HashMap<String, RecordValue>(mapCapacity(size)).apply {
+    return HashMap<String, RecordValue>(mapCapacity(size), LOAD_FACTOR).apply {
       repeat(size) {
         val key = readString()
         put(
@@ -351,7 +345,7 @@ internal object RecordSerializer {
     }
   }
 
-  private const val LOAD_FACTOR = 0.75
+  private const val LOAD_FACTOR = 0.75F
 
   private const val FIRST = 255 - 32
 
@@ -384,7 +378,6 @@ internal object RecordSerializer {
   private const val mutationPrefixShort = "\u0001"
   private const val subscriptionPrefixShort = "\u0002"
 
-  // `replaceFirst` would scan for the prefix a second time, having just established it is there.
   private fun String.shortenCacheKey(): String {
     return if (startsWith(mutationPrefixLong)) {
       mutationPrefixShort + substring(mutationPrefixLong.length)

--- a/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordSerializer.kt
+++ b/normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/RecordSerializer.kt
@@ -17,20 +17,40 @@ import okio.utf8Size
 internal object RecordSerializer {
   fun serialize(record: Record): ByteArray {
     val buffer = Buffer()
-    buffer.writeMap(record.fields)
-    buffer._writeInt(record.metadata.size)
-    for ((k, v) in record.metadata) {
-      buffer.writeString(k.shortenCacheKey())
-      buffer.writeMetadataMap(v)
-    }
+    buffer.writeRecord(record)
     return buffer.readByteArray()
   }
 
-  fun deserialize(key: String, bytes: ByteArray): Record {
-    val buffer = Buffer().write(bytes)
+  /**
+   * The number of bytes [serialize] would return for [record], without allocating the [ByteArray] to
+   * hold them.
+   */
+  fun serializedSize(record: Record): Int {
+    val buffer = Buffer()
+    buffer.writeRecord(record)
+    return buffer.size.toInt()
+  }
+
+  private fun Buffer.writeRecord(record: Record) {
+    writeMap(record.fields)
+    _writeInt(record.metadata.size)
+    for ((k, v) in record.metadata) {
+      writeString(k.shortenCacheKey())
+      writeMetadataMap(v)
+    }
+  }
+
+  /**
+   * Reads a record from [buffer], consuming exactly the bytes [serialize] wrote for it.
+   *
+   * Taking the buffer rather than a [ByteArray] lets the caller stream rows straight into the
+   * deserializer: going through `readByteArray()` copies the bytes out of the buffer only for this
+   * method to copy them back into another one.
+   */
+  fun deserialize(key: String, buffer: Buffer): Record {
     val fields = buffer.readMap()
     val metadataSize = buffer._readInt()
-    val metadata = HashMap<String, Map<String, ApolloJsonElement>>(metadataSize).apply {
+    val metadata = HashMap<String, Map<String, ApolloJsonElement>>(mapCapacity(metadataSize)).apply {
       repeat(metadataSize) {
         val k = buffer.readString().expandCacheKey()
         val v = buffer.readMetadataMap()
@@ -44,6 +64,13 @@ internal object RecordSerializer {
         metadata = metadata
     )
   }
+
+  /**
+   * The capacity to give a [HashMap] that is about to receive [size] entries, so that it does not
+   * rehash on the way there. [HashMap] grows once it is [LOAD_FACTOR] full, so sizing it to [size]
+   * exactly rehashes every map of more than 3 entries.
+   */
+  private fun mapCapacity(size: Int): Int = (size / LOAD_FACTOR).toInt() + 1
 
   private fun Buffer.writeString(value: String) {
     _writeInt(value.utf8Size().toInt())
@@ -128,7 +155,7 @@ internal object RecordSerializer {
 
   private fun Buffer.readMap(): Map<String, RecordValue> {
     val size = _readInt()
-    return HashMap<String, RecordValue>(size).apply {
+    return HashMap<String, RecordValue>(mapCapacity(size)).apply {
       repeat(size) {
         put(readString(), readAny())
       }
@@ -152,7 +179,7 @@ internal object RecordSerializer {
 
   private fun Buffer.readMetadataMap(): Map<String, RecordValue> {
     val size = _readInt()
-    return HashMap<String, RecordValue>(size).apply {
+    return HashMap<String, RecordValue>(mapCapacity(size)).apply {
       repeat(size) {
         val key = readString()
         put(
@@ -278,8 +305,10 @@ internal object RecordSerializer {
 
         LIST -> {
           val size = _readInt()
-          0.until(size).map {
-            readAny()
+          ArrayList<RecordValue>(size).apply {
+            repeat(size) {
+              add(readAny())
+            }
           }
         }
 
@@ -322,6 +351,8 @@ internal object RecordSerializer {
     }
   }
 
+  private const val LOAD_FACTOR = 0.75
+
   private const val FIRST = 255 - 32
 
   private const val NULL = FIRST
@@ -353,11 +384,12 @@ internal object RecordSerializer {
   private const val mutationPrefixShort = "\u0001"
   private const val subscriptionPrefixShort = "\u0002"
 
+  // `replaceFirst` would scan for the prefix a second time, having just established it is there.
   private fun String.shortenCacheKey(): String {
     return if (startsWith(mutationPrefixLong)) {
-      replaceFirst(mutationPrefixLong, mutationPrefixShort)
+      mutationPrefixShort + substring(mutationPrefixLong.length)
     } else if (startsWith(subscriptionPrefixLong)) {
-      replaceFirst(subscriptionPrefixLong, subscriptionPrefixShort)
+      subscriptionPrefixShort + substring(subscriptionPrefixLong.length)
     } else {
       this
     }
@@ -365,9 +397,9 @@ internal object RecordSerializer {
 
   private fun String.expandCacheKey(): String {
     return if (startsWith(mutationPrefixShort)) {
-      replaceFirst(mutationPrefixShort, mutationPrefixLong)
+      mutationPrefixLong + substring(mutationPrefixShort.length)
     } else if (startsWith(subscriptionPrefixShort)) {
-      replaceFirst(subscriptionPrefixShort, subscriptionPrefixLong)
+      subscriptionPrefixLong + substring(subscriptionPrefixShort.length)
     } else {
       this
     }

--- a/normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheTest.kt
+++ b/normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCacheTest.kt
@@ -19,6 +19,7 @@ import com.apollographql.cache.normalized.testing.Platform
 import com.apollographql.cache.normalized.testing.fieldKey
 import com.apollographql.cache.normalized.testing.platform
 import com.apollographql.cache.normalized.testing.runTest
+import kotlinx.coroutines.flow.toList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -97,6 +98,72 @@ class SqlNormalizedCacheTest {
     assertNotNull(record)
     assertEquals(expected = "valueUpdated", actual = record.fields["fieldKey"])
     assertEquals(expected = true, actual = record.fields["newFieldKey"])
+  }
+
+  /**
+   * A record larger than the 1 MiB blob chunk size is stored as several rows and reassembled on read.
+   * The fast path that skips chunking altogether covers everything smaller, so these are the only
+   * records that go through the slicing loop.
+   */
+  @Test
+  fun testLargeRecordSpanningSeveralChunks() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val record = Record(
+        key = STANDARD_KEY,
+        fields = mapOf(
+            "before" to "value1",
+            // Long enough to need three chunks on its own.
+            "large" to "a".repeat(2 * BLOB_CHUNK_SIZE + 1),
+            "after" to "value2",
+        ),
+    )
+    cache.merge(record = record, cacheHeaders = CacheHeaders.NONE, recordMerger = DefaultRecordMerger)
+
+    val loaded = assertNotNull(cache.loadRecord(STANDARD_KEY, CacheHeaders.NONE))
+    assertEquals(record.fields, loaded.fields)
+  }
+
+  /**
+   * The read path accumulates the chunks of a record in a buffer it reuses for the next one, so a
+   * multi-chunk record read alongside others must not spill into them.
+   */
+  @Test
+  fun testLargeRecordLoadedAlongsideOthers() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val small1 = Record(key = CacheKey("small1"), fields = mapOf("field" to "value1"))
+    val large = Record(key = CacheKey("large"), fields = mapOf("field" to "b".repeat(BLOB_CHUNK_SIZE + 1)))
+    val small2 = Record(key = CacheKey("small2"), fields = mapOf("field" to "value2"))
+    cache.merge(records = listOf(small1, large, small2), cacheHeaders = CacheHeaders.NONE, recordMerger = DefaultRecordMerger)
+
+    val loaded = cache.loadRecords(listOf(small1.key, large.key, small2.key), CacheHeaders.NONE).associateBy { it.key }
+    assertEquals(setOf(small1.key, large.key, small2.key), loaded.keys)
+    assertEquals(small1.fields, loaded.getValue(small1.key).fields)
+    assertEquals(large.fields, loaded.getValue(large.key).fields)
+    assertEquals(small2.fields, loaded.getValue(small2.key).fields)
+
+    val all = cache.loadAllRecords().toList().associateBy { it.key }
+    assertEquals(setOf(small1.key, large.key, small2.key), all.keys)
+    assertEquals(large.fields, all.getValue(large.key).fields)
+  }
+
+  /**
+   * Rewriting a record that used to span several chunks must not leave the extra rows behind, or the
+   * next read would append them to the new value.
+   */
+  @Test
+  fun testLargeRecordShrinks() = runTest(before = { setUp() }, after = { tearDown() }) {
+    cache.merge(
+        record = Record(key = STANDARD_KEY, fields = mapOf("field" to "c".repeat(2 * BLOB_CHUNK_SIZE))),
+        cacheHeaders = CacheHeaders.NONE,
+        recordMerger = DefaultRecordMerger,
+    )
+    // A different, small value for the same field: the merged record now fits in a single chunk.
+    cache.merge(
+        record = Record(key = STANDARD_KEY, fields = mapOf("field" to "small")),
+        cacheHeaders = CacheHeaders.NONE,
+        recordMerger = DefaultRecordMerger,
+    )
+
+    val loaded = assertNotNull(cache.loadRecord(STANDARD_KEY, CacheHeaders.NONE))
+    assertEquals(mapOf("field" to "small"), loaded.fields)
   }
 
   @Test
@@ -438,5 +505,10 @@ class SqlNormalizedCacheTest {
   companion object {
     val STANDARD_KEY = CacheKey("key")
     val QUERY_ROOT_KEY = CacheKey.QUERY_ROOT
+
+    /**
+     * Mirrors `BLOB_CHUNK_SIZE` in `RecordDatabase`, which is private to it.
+     */
+    const val BLOB_CHUNK_SIZE = 1024 * 1024
   }
 }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/ApolloStore.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/ApolloStore.kt
@@ -18,6 +18,7 @@ import com.apollographql.cache.normalized.api.DataWithErrors
 import com.apollographql.cache.normalized.api.DefaultRecordMerger
 import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.Record
+import com.apollographql.cache.normalized.api.dependentKeys
 import com.apollographql.cache.normalized.api.rootKey
 import com.apollographql.cache.normalized.api.withErrors
 import com.benasher44.uuid.Uuid
@@ -518,7 +519,7 @@ private suspend fun <D : Executable.Data> ApolloStore.removeData(
         recordMerger = DefaultRecordMerger
     )
   }
-  return normalizationRecords.values.flatMap { it.fieldKeys() }.toSet().also { if (publish) publish(it) }
+  return normalizationRecords.values.dependentKeys().also { if (publish) publish(it) }
 }
 
 private val EmptyExecutionOptions = object : ExecutionOptions {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
@@ -206,8 +206,6 @@ object DefaultCacheResolver : CacheResolver {
   override fun resolveField(context: ResolverContext): Any? {
     val fieldKey = context.getFieldKey()
     val value = context.parent[fieldKey]
-    // Only a null value is ambiguous between a cache miss and a field whose value is null, so
-    // `containsKey` is only needed then rather than for every field.
     if (value == null && !context.parent.containsKey(fieldKey)) {
       throw CacheMissException(context.parentKey.keyToString(), fieldKey)
     }
@@ -249,12 +247,10 @@ class CacheControlCacheResolver(
   )
 
   /**
-   * The max age of every field, when [maxAgeProvider] gives them all the same one. The provider then
-   * ignores the field path, and the path is not built at all: it holds a [MaxAgeContext.Field] per
-   * level, each of which walks its type's interface hierarchy.
+   * Optimization: when [maxAgeProvider] is [GlobalMaxAgeProvider] all fields have the same max age.
    */
   private val globalMaxAge: Duration? = if (maxAgeProvider is GlobalMaxAgeProvider) {
-    maxAgeProvider.getMaxAge(MaxAgeContext(emptyList()))
+    maxAgeProvider.maxAge
   } else {
     null
   }
@@ -267,8 +263,6 @@ class CacheControlCacheResolver(
     }
     var isStale = false
     if (context.parent is Record) {
-      // Computed once: the default generator formats the field's arguments as JSON, which is more
-      // than we want to redo for each of the five places below that need the key.
       val fieldKey = context.getFieldKey()
       // Consider the client controlled max age
       val receivedDate = context.parent.receivedDate(fieldKey)
@@ -389,8 +383,6 @@ class KeyArgumentsCacheResolver(
   override fun resolveField(context: ResolverContext): Any? {
     val fieldKey = context.getFieldKey()
     val value = context.parent[fieldKey]
-    // Only a null value is ambiguous between a cache miss and a field whose value is null, so
-    // `containsKey` is only needed then rather than for every field.
     if (value != null || context.parent.containsKey(fieldKey)) {
       return value
     }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
@@ -204,11 +204,14 @@ private fun ResolverContext.listItemsInParent(keyArg: String): Map<Any?, Any?> {
 object DefaultCacheResolver : CacheResolver {
   override fun resolveField(context: ResolverContext): Any? {
     val fieldKey = context.getFieldKey()
-    if (!context.parent.containsKey(fieldKey)) {
+    val value = context.parent[fieldKey]
+    // Only a null value is ambiguous between a cache miss and a field whose value is null, so
+    // `containsKey` is only needed then rather than for every field.
+    if (value == null && !context.parent.containsKey(fieldKey)) {
       throw CacheMissException(context.parentKey.keyToString(), fieldKey)
     }
 
-    return context.parent[fieldKey]
+    return value
   }
 }
 
@@ -252,8 +255,11 @@ class CacheControlCacheResolver(
     }
     var isStale = false
     if (context.parent is Record) {
+      // Computed once: the default generator formats the field's arguments as JSON, which is more
+      // than we want to redo for each of the five places below that need the key.
+      val fieldKey = context.getFieldKey()
       // Consider the client controlled max age
-      val receivedDate = context.parent.receivedDate(context.getFieldKey())
+      val receivedDate = context.parent.receivedDate(fieldKey)
       val currentDate = context.cacheHeaders.headerValue(ApolloCacheHeaders.CURRENT_DATE)?.toLongOrNull() ?: (currentTimeMillis() / 1000)
       if (receivedDate != null) {
         val age = currentDate - receivedDate
@@ -266,7 +272,7 @@ class CacheControlCacheResolver(
         if (staleDuration >= maxStale) {
           throw CacheMissException(
               key = context.parentKey.keyToString(),
-              fieldName = context.getFieldKey(),
+              fieldName = fieldKey,
               stale = true,
           )
         }
@@ -274,14 +280,14 @@ class CacheControlCacheResolver(
       }
 
       // Consider the server controlled max age
-      val expirationDate = context.parent.expirationDate(context.getFieldKey())
+      val expirationDate = context.parent.expirationDate(fieldKey)
       if (expirationDate != null) {
         val staleDuration = currentDate - expirationDate
         val maxStale = context.cacheHeaders.headerValue(ApolloCacheHeaders.MAX_STALE)?.toLongOrNull() ?: 0L
         if (staleDuration >= maxStale) {
           throw CacheMissException(
               key = context.parentKey.keyToString(),
-              fieldName = context.getFieldKey(),
+              fieldName = fieldKey,
               stale = true,
           )
         }
@@ -292,7 +298,7 @@ class CacheControlCacheResolver(
         // We can't determine the field's staleness: consider it stale
         throw CacheMissException(
             key = context.parentKey.keyToString(),
-            fieldName = context.getFieldKey(),
+            fieldName = fieldKey,
             stale = true,
         )
       }
@@ -371,8 +377,11 @@ class KeyArgumentsCacheResolver(
 
   override fun resolveField(context: ResolverContext): Any? {
     val fieldKey = context.getFieldKey()
-    if (context.parent.containsKey(fieldKey)) {
-      return context.parent[fieldKey]
+    val value = context.parent[fieldKey]
+    // Only a null value is ambiguous between a cache miss and a field whose value is null, so
+    // `containsKey` is only needed then rather than for every field.
+    if (value != null || context.parent.containsKey(fieldKey)) {
+      return value
     }
     val keyArgs = keyArgumentsProvider.getKeyArguments(context.parentType, context.field)
         .ifEmpty { return delegateResolver.resolveField(context) }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheResolver.kt
@@ -16,6 +16,7 @@ import com.apollographql.cache.normalized.storeExpirationDate
 import com.apollographql.cache.normalized.storeReceivedDate
 import okio.Buffer
 import kotlin.jvm.JvmSuppressWildcards
+import kotlin.time.Duration
 
 /**
  * Controls how fields are resolved from the cache.
@@ -247,6 +248,17 @@ class CacheControlCacheResolver(
       delegateResolver = FieldPolicyCacheResolver(fieldPolicies = fieldPolicies, keyScope = CacheKey.Scope.TYPE),
   )
 
+  /**
+   * The max age of every field, when [maxAgeProvider] gives them all the same one. The provider then
+   * ignores the field path, and the path is not built at all: it holds a [MaxAgeContext.Field] per
+   * level, each of which walks its type's interface hierarchy.
+   */
+  private val globalMaxAge: Duration? = if (maxAgeProvider is GlobalMaxAgeProvider) {
+    maxAgeProvider.getMaxAge(MaxAgeContext(emptyList()))
+  } else {
+    null
+  }
+
   override fun resolveField(context: ResolverContext): Any? {
     val value = delegateResolver.resolveField(context)
     if (value.isSyntheticValue) {
@@ -263,10 +275,9 @@ class CacheControlCacheResolver(
       val currentDate = context.cacheHeaders.headerValue(ApolloCacheHeaders.CURRENT_DATE)?.toLongOrNull() ?: (currentTimeMillis() / 1000)
       if (receivedDate != null) {
         val age = currentDate - receivedDate
-        val fieldPath = context.path.map {
-          it.toMaxAgeField()
-        }
-        val maxAge = maxAgeProvider.getMaxAge(MaxAgeContext(fieldPath)).inWholeSeconds
+        val maxAge = (
+            globalMaxAge ?: maxAgeProvider.getMaxAge(MaxAgeContext(context.path.map { it.toMaxAgeField() }))
+            ).inWholeSeconds
         val staleDuration = age - maxAge
         val maxStale = context.cacheHeaders.headerValue(ApolloCacheHeaders.MAX_STALE)?.toLongOrNull() ?: 0L
         if (staleDuration >= maxStale) {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/DataWithErrors.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/DataWithErrors.kt
@@ -127,8 +127,9 @@ internal fun processErrors(
       }
       @Suppress("UNCHECKED_CAST")
       dataWithErrors as Map<String, Any?>
+      val fieldSelections = field.fieldSelections()
       dataWithErrors.mapValues { (key, value) ->
-        val selection = field.fieldSelection(key)
+        val selection = fieldSelections[key]
             ?: // Should never happen
             return@mapValues value
         when (value) {
@@ -197,23 +198,40 @@ internal fun processErrors(
 
 internal class OnErrorHaltException : Exception("A field resolved to an error and OnError is set to HALT")
 
-private fun CompiledSelection.fieldSelection(responseName: String): CompiledField? {
-  fun CompiledSelection.fieldSelections(): List<CompiledField> {
-    return when (this) {
-      is CompiledField -> selections.filterIsInstance<CompiledField>() + selections.filterIsInstance<CompiledFragment>()
-          .flatMap { it.fieldSelections() }
+/**
+ * Maps each response name this field selects to the selection it resolves to.
+ *
+ * Built once and reused for every key of the object: resolving one response name at a time re-flattens
+ * the whole selection set per key, which is quadratic in the number of fields selected.
+ */
+private fun CompiledField.fieldSelections(): Map<String, CompiledField> {
+  val fieldSelections = mutableMapOf<String, CompiledField>()
 
-      is CompiledFragment -> selections.filterIsInstance<CompiledField>() + selections.filterIsInstance<CompiledFragment>()
-          .flatMap { it.fieldSelections() }
+  fun collect(selections: List<CompiledSelection>) {
+    for (selection in selections) {
+      if (selection !is CompiledField) continue
+      val existing = fieldSelections[selection.responseName]
+      fieldSelections[selection.responseName] = if (existing == null) {
+        selection
+      } else {
+        // Fields can be selected multiple times, combine the selections
+        CompiledField.Builder(
+            name = existing.name,
+            type = existing.type,
+        )
+            .selections(existing.selections + selection.selections)
+            .build()
+      }
+    }
+    // Fragments are visited after the fields of the enclosing selection set, so that a field selected
+    // both directly and in a fragment keeps the direct selection's name and type.
+    for (selection in selections) {
+      if (selection is CompiledFragment) {
+        collect(selection.selections)
+      }
     }
   }
-  // Fields can be selected multiple times, combine the selections
-  return fieldSelections().filter { it.responseName == responseName }.reduceOrNull { acc, compiledField ->
-    CompiledField.Builder(
-        name = acc.name,
-        type = acc.type,
-    )
-        .selections(acc.selections + compiledField.selections)
-        .build()
-  }
+
+  collect(selections)
+  return fieldSelections
 }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/DataWithErrors.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/DataWithErrors.kt
@@ -200,9 +200,6 @@ internal class OnErrorHaltException : Exception("A field resolved to an error an
 
 /**
  * Maps each response name this field selects to the selection it resolves to.
- *
- * Built once and reused for every key of the object: resolving one response name at a time re-flattens
- * the whole selection set per key, which is quadratic in the number of fields selected.
  */
 private fun CompiledField.fieldSelections(): Map<String, CompiledField> {
   val fieldSelections = mutableMapOf<String, CompiledField>()

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/MaxAgeProvider.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/MaxAgeProvider.kt
@@ -35,7 +35,7 @@ class MaxAgeContext(
 /**
  * A provider that returns a single max age for all types.
  */
-class GlobalMaxAgeProvider(private val maxAge: Duration) : MaxAgeProvider {
+class GlobalMaxAgeProvider(internal val maxAge: Duration) : MaxAgeProvider {
   override fun getMaxAge(maxAgeContext: MaxAgeContext): Duration = maxAge
 }
 

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/Record.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/Record.kt
@@ -38,8 +38,6 @@ class Record(
    * A field key incorporates any GraphQL arguments in addition to the field name.
    */
   fun fieldKeys(): Set<String> {
-    // Built in one pass: `map {}.toSet()` would allocate a list holding every key on top of the set
-    // actually returned.
     return buildSet(fields.size) {
       for (fieldName in fields.keys) {
         add(key.fieldKey(fieldName))
@@ -83,18 +81,13 @@ class Record(
 
   companion object {
     internal fun changedKeys(record1: Record, record2: Record): Set<String> {
-      check(record1.key == record2.key) {
-        "Cannot compute changed keys on record with different keys: '${record1.key}' - '${record2.key}'"
-      }
-      // Built in one pass: going through set arithmetic allocates an intersection, two differences,
-      // a filtered list and a mapped list before the set actually returned.
       val fields1 = record1.fields
       val fields2 = record2.fields
       return buildSet {
         for ((fieldName, value1) in fields1) {
           val value2 = fields2[fieldName]
           // Differing values mean the field changed, and so does a field missing from `fields2`. A
-          // null `value2` is ambiguous between the two, so `containsKey` is only needed then.
+          // null `value2` is ambiguous between the two, so use `containsKey` to disambiguate.
           if (value1 != value2 || (value1 == null && !fields2.containsKey(fieldName))) {
             add(record1.key.fieldKey(fieldName))
           }
@@ -114,8 +107,6 @@ fun Record.withDates(receivedDate: String?, expirationDate: String?): Record {
   if (receivedDate == null && expirationDate == null) {
     return this
   }
-  // The dates are the same for every field, so the map holding them is built once rather than per
-  // field.
   val dates = buildMap<String, ApolloJsonElement>(2) {
     receivedDate?.let {
       put(ApolloCacheHeaders.RECEIVED_DATE, it.toLong())
@@ -169,9 +160,6 @@ fun Collection<Record>?.dependentKeys(): Set<String> {
   if (this == null) {
     return emptySet()
   }
-  // Built in one pass: going through `fieldKeys()` would allocate a list and a set per record, plus
-  // a list holding every key, on top of the set actually returned. For a large operation that is
-  // thousands of throwaway collections.
   return buildSet {
     for (record in this@dependentKeys) {
       for (fieldName in record.fields.keys) {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/Record.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/Record.kt
@@ -38,7 +38,13 @@ class Record(
    * A field key incorporates any GraphQL arguments in addition to the field name.
    */
   fun fieldKeys(): Set<String> {
-    return fields.keys.map { key.fieldKey(it) }.toSet()
+    // Built in one pass: `map {}.toSet()` would allocate a list holding every key on top of the set
+    // actually returned.
+    return buildSet(fields.size) {
+      for (fieldName in fields.keys) {
+        add(key.fieldKey(fieldName))
+      }
+    }
   }
 
   /**
@@ -80,15 +86,25 @@ class Record(
       check(record1.key == record2.key) {
         "Cannot compute changed keys on record with different keys: '${record1.key}' - '${record2.key}'"
       }
-      val keys1 = record1.fields.keys
-      val keys2 = record2.fields.keys
-      val intersection = keys1.intersect(keys2)
-
-      val changed = (keys1 - intersection) + (keys2 - intersection) + intersection.filter {
-        record1.fields[it] != record2.fields[it]
+      // Built in one pass: going through set arithmetic allocates an intersection, two differences,
+      // a filtered list and a mapped list before the set actually returned.
+      val fields1 = record1.fields
+      val fields2 = record2.fields
+      return buildSet {
+        for ((fieldName, value1) in fields1) {
+          val value2 = fields2[fieldName]
+          // Differing values mean the field changed, and so does a field missing from `fields2`. A
+          // null `value2` is ambiguous between the two, so `containsKey` is only needed then.
+          if (value1 != value2 || (value1 == null && !fields2.containsKey(fieldName))) {
+            add(record1.key.fieldKey(fieldName))
+          }
+        }
+        for (fieldName in fields2.keys) {
+          if (!fields1.containsKey(fieldName)) {
+            add(record1.key.fieldKey(fieldName))
+          }
+        }
       }
-
-      return changed.map { record1.key.fieldKey(it) }.toSet()
     }
   }
 }
@@ -98,19 +114,22 @@ fun Record.withDates(receivedDate: String?, expirationDate: String?): Record {
   if (receivedDate == null && expirationDate == null) {
     return this
   }
+  // The dates are the same for every field, so the map holding them is built once rather than per
+  // field.
+  val dates = buildMap<String, ApolloJsonElement>(2) {
+    receivedDate?.let {
+      put(ApolloCacheHeaders.RECEIVED_DATE, it.toLong())
+    }
+    expirationDate?.let {
+      put(ApolloCacheHeaders.EXPIRATION_DATE, it.toLong())
+    }
+  }
   return Record(
       key = key,
       fields = fields,
       mutationId = mutationId,
       metadata = metadata + fields.mapValues { (key, _) ->
-        metadata[key].orEmpty() + buildMap {
-          receivedDate?.let {
-            put(ApolloCacheHeaders.RECEIVED_DATE, it.toLong())
-          }
-          expirationDate?.let {
-            put(ApolloCacheHeaders.EXPIRATION_DATE, it.toLong())
-          }
-        }
+        metadata[key].orEmpty() + dates
       }
   )
 }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/RecordMerger.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/RecordMerger.kt
@@ -32,14 +32,17 @@ object DefaultRecordMerger : RecordMerger {
     val incoming = context.incoming
     val errorsReplaceCachedValues = context.cacheHeaders.headerValue(ApolloCacheHeaders.ERRORS_REPLACE_CACHED_VALUES) == "true"
     val changedKeys = mutableSetOf<String>()
-    val mergedFields = existing.fields.toMutableMap()
+    val existingFields = existing.fields
+    val mergedFields = existingFields.toMutableMap()
 
     for ((fieldKey, incomingFieldValue) in incoming.fields) {
-      val hasExistingFieldValue = existing.fields.containsKey(fieldKey)
+      val existingFieldValue = existingFields[fieldKey]
+      // Only a null value is ambiguous between "absent" and "present and null", so `containsKey` is
+      // only needed then rather than for every field.
+      val hasExistingFieldValue = existingFieldValue != null || existingFields.containsKey(fieldKey)
       if (hasExistingFieldValue && incomingFieldValue is Error && !errorsReplaceCachedValues) {
         continue
       }
-      val existingFieldValue = existing.fields[fieldKey]
       if (!hasExistingFieldValue || existingFieldValue != incomingFieldValue) {
         mergedFields[fieldKey] = incomingFieldValue
         changedKeys.add(existing.key.fieldKey(fieldKey))
@@ -56,6 +59,10 @@ object DefaultRecordMerger : RecordMerger {
 }
 
 private fun Map<String, Map<String, ApolloJsonElement>>.mergedWith(incoming: Map<String, Map<String, ApolloJsonElement>>): Map<String, Map<String, ApolloJsonElement>> {
+  // Metadata is empty unless a MetadataGenerator is configured, which is the default. Short-circuit
+  // rather than copy a map to merge nothing into it.
+  if (incoming.isEmpty()) return this
+  if (isEmpty()) return incoming
   return toMutableMap().also { existing ->
     for ((incomingField, incomingMetadataForField) in incoming) {
       existing[incomingField] = existing[incomingField].orEmpty() + incomingMetadataForField
@@ -96,15 +103,18 @@ class FieldRecordMerger(private val fieldMerger: FieldMerger) : RecordMerger {
     val incoming = context.incoming
     val errorsReplaceCachedValues = context.cacheHeaders.headerValue(ApolloCacheHeaders.ERRORS_REPLACE_CACHED_VALUES) == "true"
     val changedKeys = mutableSetOf<String>()
-    val mergedFields = existing.fields.toMutableMap()
+    val existingFields = existing.fields
+    val mergedFields = existingFields.toMutableMap()
     val mergedMetadata = existing.metadata.toMutableMap()
 
     for ((fieldKey, incomingFieldValue) in incoming.fields) {
-      val hasExistingFieldValue = existing.fields.containsKey(fieldKey)
+      val existingFieldValue = existingFields[fieldKey]
+      // Only a null value is ambiguous between "absent" and "present and null", so `containsKey` is
+      // only needed then rather than for every field.
+      val hasExistingFieldValue = existingFieldValue != null || existingFields.containsKey(fieldKey)
       if (hasExistingFieldValue && incomingFieldValue is Error && !errorsReplaceCachedValues) {
         continue
       }
-      val existingFieldValue = existing.fields[fieldKey]
       if (!hasExistingFieldValue) {
         mergedFields[fieldKey] = incomingFieldValue
         mergedMetadata[fieldKey] = incoming.metadata[fieldKey].orEmpty()

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/RecordMerger.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/RecordMerger.kt
@@ -37,8 +37,6 @@ object DefaultRecordMerger : RecordMerger {
 
     for ((fieldKey, incomingFieldValue) in incoming.fields) {
       val existingFieldValue = existingFields[fieldKey]
-      // Only a null value is ambiguous between "absent" and "present and null", so `containsKey` is
-      // only needed then rather than for every field.
       val hasExistingFieldValue = existingFieldValue != null || existingFields.containsKey(fieldKey)
       if (hasExistingFieldValue && incomingFieldValue is Error && !errorsReplaceCachedValues) {
         continue
@@ -59,8 +57,6 @@ object DefaultRecordMerger : RecordMerger {
 }
 
 private fun Map<String, Map<String, ApolloJsonElement>>.mergedWith(incoming: Map<String, Map<String, ApolloJsonElement>>): Map<String, Map<String, ApolloJsonElement>> {
-  // Metadata is empty unless a MetadataGenerator is configured, which is the default. Short-circuit
-  // rather than copy a map to merge nothing into it.
   if (incoming.isEmpty()) return this
   if (isEmpty()) return incoming
   return toMutableMap().also { existing ->
@@ -109,8 +105,6 @@ class FieldRecordMerger(private val fieldMerger: FieldMerger) : RecordMerger {
 
     for ((fieldKey, incomingFieldValue) in incoming.fields) {
       val existingFieldValue = existingFields[fieldKey]
-      // Only a null value is ambiguous between "absent" and "present and null", so `containsKey` is
-      // only needed then rather than for every field.
       val hasExistingFieldValue = existingFieldValue != null || existingFields.containsKey(fieldKey)
       if (hasExistingFieldValue && incomingFieldValue is Error && !errorsReplaceCachedValues) {
         continue

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
@@ -165,10 +165,7 @@ internal class CacheBatchReader(
     val state = CollectState(variables)
     collect(selections, parentType, typename, state)
     val fields = state.fields
-    // Nothing to merge when every field has its own response name, which is the common shape. Each
-    // field is then a group of one and already its own merge result, so grouping would only allocate a
-    // Pair to hash it by, then a builder and a selection list to rebuild a copy equal to it - for
-    // every field of every object read.
+    // Optimization: no need to merge when every field has its own response name.
     val responseNames = HashSet<String>()
     var hasSameResponseName = false
     for (field in fields) {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
@@ -103,8 +103,24 @@ internal class CacheBatchReader(
   ): List<CompiledField> {
     val state = CollectState(variables)
     collect(selections, parentType, typename, state)
-    return state.fields.groupBy { (it.responseName) to it.condition }.values.map { fields ->
-      fields.first().newBuilder().selections(fields.flatMap { it.selections }).build()
+    val fields = state.fields
+    // Nothing to merge when every field has its own response name, which is the common shape. Each
+    // field is then a group of one and already its own merge result, so grouping would only allocate a
+    // Pair to hash it by, then a builder and a selection list to rebuild a copy equal to it - for
+    // every field of every object read.
+    val responseNames = HashSet<String>()
+    var hasSameResponseName = false
+    for (field in fields) {
+      if (!responseNames.add(field.responseName)) {
+        hasSameResponseName = true
+        break
+      }
+    }
+    if (!hasSameResponseName) {
+      return fields
+    }
+    return fields.groupBy { (it.responseName) to it.condition }.values.map { sameDirectives ->
+      sameDirectives.first().newBuilder().selections(sameDirectives.flatMap { it.selections }).build()
     }
   }
 

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
@@ -21,6 +21,65 @@ import com.apollographql.cache.normalized.cacheMissException
 import kotlin.jvm.JvmSuppressWildcards
 
 /**
+ * A node in the tree of response paths.
+ *
+ * The paths of a response all share prefixes, so they are interned into a tree rather than held as
+ * lists: appending a segment is a lookup on the parent node instead of a copy of the whole path, and
+ * keying a map on a path hashes an identity instead of walking its segments. Every path is also asked
+ * for more than once - the reader builds one per field of every object it reads, then walks them all
+ * again to assemble the result - and interning hands back the node built the first time instead of
+ * rebuilding the list.
+ *
+ * Two paths are the same node if and only if they have the same segments, which is what lets identity
+ * stand in for equality.
+ *
+ * [append] mutates the tree, so a tree belongs to the single read that builds it.
+ */
+internal class ResponsePath private constructor(
+    private val parent: ResponsePath?,
+    private val segment: Any?,
+) {
+  private var children: MutableMap<Any, ResponsePath>? = null
+
+  fun append(segment: Any): ResponsePath {
+    var children = this.children
+    if (children == null) {
+      // Only composite fields ever get children, so leaves carry no map at all.
+      children = mutableMapOf()
+      this.children = children
+    }
+    var child = children[segment]
+    if (child == null) {
+      child = ResponsePath(parent = this, segment = segment)
+      children[segment] = child
+    }
+    return child
+  }
+
+  /**
+   * This path as a list of segments, root first. Only needed to fill in the `path` of the errors
+   * reported for cache misses.
+   */
+  fun asList(): List<Any> {
+    val segments = mutableListOf<Any>()
+    var node: ResponsePath = this
+    while (true) {
+      val parent = node.parent ?: break
+      segments.add(node.segment!!)
+      node = parent
+    }
+    segments.reverse()
+    return segments
+  }
+
+  override fun toString(): String = asList().joinToString(".")
+
+  companion object {
+    fun root(): ResponsePath = ResponsePath(parent = null, segment = null)
+  }
+}
+
+/**
  * A resolver that solves the "N+1" problem by batching all SQL queries at a given depth.
  * It respects skip/include directives.
  */
@@ -50,18 +109,20 @@ internal class CacheBatchReader(
    */
   class PendingReference(
       val key: CacheKey,
-      val path: List<Any>,
+      val path: ResponsePath,
       val fieldPath: List<CompiledField>,
       val selections: List<CompiledSelection>,
       val parentType: String,
   )
+
+  private val rootPath = ResponsePath.root()
 
   /**
    * The objects read from the cache, as a `Map<String, Any?>` with only the fields that are selected and maybe some values changed.
    * Can also be an [Error] in case of a cache miss.
    * The key is the path to the object.
    */
-  private val data = mutableMapOf<List<Any>, Any>()
+  private val data = mutableMapOf<ResponsePath, Any>()
 
   /**
    * True if at least one of the resolved fields is stale
@@ -130,7 +191,7 @@ internal class CacheBatchReader(
             key = rootKey,
             selections = rootSelections,
             parentType = rootField.type.rawType().name,
-            path = emptyList(),
+            path = rootPath,
             fieldPath = listOf(rootField),
         ),
     )
@@ -166,6 +227,7 @@ internal class CacheBatchReader(
             return@mapNotNull null
           }
 
+          val valuePath = pendingReference.path.append(it.responseName)
           val value = try {
             cacheResolver.resolveField(
                 ResolverContext(
@@ -185,7 +247,7 @@ internal class CacheBatchReader(
               throw e
             } else {
               hasErrors = true
-              cacheMissError(e, pendingReference.path + it.responseName)
+              cacheMissError(e, valuePath)
             }
           }.also { value ->
             if (!hasErrors) {
@@ -199,7 +261,7 @@ internal class CacheBatchReader(
               }
             }
           }
-          value.registerCacheKeys(pendingReference.path + it.responseName, pendingReference.fieldPath + it, it.selections, it.type.rawType().name)
+          value.registerCacheKeys(valuePath, pendingReference.fieldPath + it, it.selections, it.type.rawType().name)
 
           it.responseName to value
         }.toMap()
@@ -225,6 +287,7 @@ internal class CacheBatchReader(
 
     return CacheBatchReaderData(
         data = data,
+        rootPath = rootPath,
         cacheHeaders = CacheHeaders.Builder().apply { if (isStale) addHeader(ApolloCacheHeaders.STALE, "true") }.build(),
         hasErrors = hasErrors,
     )
@@ -249,7 +312,7 @@ internal class CacheBatchReader(
    * The path leading to this value
    */
   private fun Any?.registerCacheKeys(
-      path: List<Any>,
+      path: ResponsePath,
       fieldPath: List<CompiledField>,
       selections: List<CompiledSelection>,
       parentType: String,
@@ -269,7 +332,7 @@ internal class CacheBatchReader(
 
       is List<*> -> {
         forEachIndexed { index, value ->
-          value.registerCacheKeys(path + index, fieldPath, selections, parentType)
+          value.registerCacheKeys(path.append(index), fieldPath, selections, parentType)
         }
       }
 
@@ -282,6 +345,7 @@ internal class CacheBatchReader(
             return@mapNotNull null
           }
 
+          val valuePath = path.append(it.responseName)
           val value = try {
             cacheResolver.resolveField(
                 ResolverContext(
@@ -301,26 +365,27 @@ internal class CacheBatchReader(
               throw e
             } else {
               hasErrors = true
-              cacheMissError(e, path + it.responseName)
+              cacheMissError(e, valuePath)
             }
           }
-          value.registerCacheKeys(path + it.responseName, fieldPath + it, it.selections, it.type.rawType().name)
+          value.registerCacheKeys(valuePath, fieldPath + it, it.selections, it.type.rawType().name)
         }
       }
     }
   }
 
   internal class CacheBatchReaderData(
-      private val data: Map<List<Any>, Any>,
+      private val data: Map<ResponsePath, Any>,
+      private val rootPath: ResponsePath,
       val cacheHeaders: CacheHeaders,
       val hasErrors: Boolean,
   ) {
     @Suppress("UNCHECKED_CAST")
     internal fun toMap(withErrors: Boolean = true): DataWithErrors {
-      return data[emptyList()].replaceCacheKeys(emptyList(), withErrors) as DataWithErrors
+      return data[rootPath].replaceCacheKeys(rootPath, withErrors) as DataWithErrors
     }
 
-    private fun Any?.replaceCacheKeys(path: List<Any>, withErrors: Boolean): Any? {
+    private fun Any?.replaceCacheKeys(path: ResponsePath, withErrors: Boolean): Any? {
       return when (this) {
         is CacheKey -> {
           data[path].replaceCacheKeys(path, withErrors)
@@ -328,14 +393,14 @@ internal class CacheBatchReader(
 
         is List<*> -> {
           mapIndexed { index, src ->
-            src.replaceCacheKeys(path + index, withErrors)
+            src.replaceCacheKeys(path.append(index), withErrors)
           }
         }
 
         is Map<*, *> -> {
           // This will traverse Map custom scalars but this is ok as it shouldn't contain any CacheKey
           mapValues {
-            it.value.replaceCacheKeys(path + (it.key as String), withErrors)
+            it.value.replaceCacheKeys(path.append(it.key as String), withErrors)
           }
         }
 
@@ -355,7 +420,7 @@ internal class CacheBatchReader(
     }
   }
 
-  private fun cacheMissError(exception: CacheMissException, path: List<Any>): Error {
+  private fun cacheMissError(exception: CacheMissException, path: ResponsePath): Error {
     val message = if (exception.fieldName == null) {
       "Object '${exception.key}' not found in the cache"
     } else {
@@ -366,7 +431,7 @@ internal class CacheBatchReader(
       }
     }
     return Error.Builder(message)
-        .path(path = path)
+        .path(path = path.asList())
         .cacheMissException(exception)
         .build()
   }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
@@ -355,16 +355,25 @@ internal class CacheBatchReader(
         .build()
   }
 
-  @Suppress("UNCHECKED_CAST")
+  /**
+   * The first [Error] in this value, or null if it holds none.
+   *
+   * Called for every field read, where the overwhelming majority of values are scalars holding no
+   * error at all, so it recurses rather than allocating a work queue to walk them with.
+   */
   internal fun Any?.firstError(): Error? {
-    val queue = ArrayDeque<Any?>()
-    queue.add(this)
-    while (queue.isNotEmpty()) {
-      when (val current = queue.removeFirst()) {
-        is Error -> return current
-        is List<*> -> queue.addAll(current)
-        // Embedded fields can be represented as Maps
-        is Map<*, *> -> queue.addAll(current.values)
+    when (this) {
+      is Error -> return this
+      is List<*> -> {
+        for (item in this) {
+          item.firstError()?.let { return it }
+        }
+      }
+      // Embedded fields can be represented as Maps
+      is Map<*, *> -> {
+        for (value in values) {
+          value.firstError()?.let { return it }
+        }
       }
     }
     return null

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
@@ -298,12 +298,15 @@ internal class DefaultCacheManager(
       cacheHeaders: CacheHeaders,
       publish: Boolean,
   ): Set<String> {
+    // `merge` takes a `Collection`, and the values of a map keyed by cache key are already distinct:
+    // going through a `Set` would deep-hash every record of the response for nothing
+    // (`Record.hashCode` recurses through `fields` and `metadata`).
     val records = normalize(
         executable = operation,
         dataWithErrors = dataWithErrors,
         rootKey = operation.rootKey(),
         customScalarAdapters = customScalarAdapters,
-    ).values.toSet()
+    ).values
     return cache.merge(records, cacheHeaders, recordMerger).also { if (publish) publish(it) }
   }
 

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
@@ -298,9 +298,6 @@ internal class DefaultCacheManager(
       cacheHeaders: CacheHeaders,
       publish: Boolean,
   ): Set<String> {
-    // `merge` takes a `Collection`, and the values of a map keyed by cache key are already distinct:
-    // going through a `Set` would deep-hash every record of the response for nothing
-    // (`Record.hashCode` recurses through `fields` and `metadata`).
     val records = normalize(
         executable = operation,
         dataWithErrors = dataWithErrors,

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
@@ -51,13 +51,10 @@ internal class Normalizer(
   private val records = mutableMapOf<CacheKey, Record>()
 
   /**
-   * The max age of every field, when [maxAgeProvider] gives them all the same one - which is what
-   * [DefaultMaxAgeProvider] does, so this is the usual case. The provider then ignores the field path,
-   * and the path is not built at all: it holds a [MaxAgeContext.Field] per level, each of which walks
-   * its type's interface hierarchy.
+   * Optimization: when [maxAgeProvider] is [GlobalMaxAgeProvider] all fields have the same max age.
    */
   private val globalMaxAge: Duration? = if (maxAgeProvider is GlobalMaxAgeProvider) {
-    maxAgeProvider.getMaxAge(MaxAgeContext(emptyList()))
+    maxAgeProvider.maxAge
   } else {
     null
   }

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
@@ -49,6 +49,25 @@ internal class Normalizer(
 ) {
   private val records = mutableMapOf<CacheKey, Record>()
 
+  /**
+   * Field keys, indexed by parent type name then by field. Computing one encodes the field's arguments
+   * to JSON, and the same fields are normalized again for every object of a list.
+   *
+   * [CompiledField] has no `equals`, so the inner maps key on instance identity. Only fields that are
+   * shared across objects are put here - see [buildFields].
+   */
+  private val fieldKeys = mutableMapOf<String, MutableMap<CompiledField, String>>()
+
+  private fun memoizedFieldKey(parentTypeName: String, field: CompiledField): String {
+    val keys = fieldKeys.getOrPut(parentTypeName) { mutableMapOf() }
+    var fieldKey = keys[field]
+    if (fieldKey == null) {
+      fieldKey = fieldKeyGenerator.getFieldKey(FieldKeyContext(parentTypeName, field, variables))
+      keys[field] = fieldKey
+    }
+    return fieldKey
+  }
+
   fun normalize(
       map: DataWithErrors,
       selections: List<CompiledSelection>,
@@ -83,27 +102,43 @@ internal class Normalizer(
     val allFields = collectFields(selections, parentType.name, typename)
 
     val fields = obj.entries.mapNotNull { entry ->
-      val compiledFields = allFields.filter { it.responseName == entry.key }
-      if (compiledFields.isEmpty()) {
+      val compiledFields = allFields[entry.key]
+      if (compiledFields == null) {
         // If we come here, `obj` contains more data than the CompiledSelections can understand
         // This happened previously (see https://github.com/apollographql/apollo-kotlin/pull/3636)
         // It also happens if there's an always false @include directive (see https://github.com/apollographql/apollo-kotlin/issues/4772)
         // For all cache purposes, this is not part of the response and we therefore do not include this in the response
         return@mapNotNull null
       }
-      val includedFields = compiledFields.filter {
-        !it.shouldSkip(variableValues = variables.valueMap)
+      // A lone field with no condition to clear is already the result of merging its group, so it is
+      // normalized as is: rebuilding it would allocate a copy equal to it, once per object. It is also
+      // then the same instance for every object normalized against these selections, which is what
+      // makes its field key worth memoizing - a merged field is a new instance every time, so keeping
+      // its key would only retain the copy.
+      val sharedField = compiledFields.singleOrNull()?.takeIf { it.condition.isEmpty() }
+      val mergedField: CompiledField
+      val fieldKey: String
+      if (sharedField != null) {
+        if (sharedField.shouldSkip(variableValues = variables.valueMap)) {
+          // If the field is absent, we don't want to serialize "null" to the cache, do not include this field in the record.
+          return@mapNotNull null
+        }
+        mergedField = sharedField
+        fieldKey = memoizedFieldKey(parentType.name, sharedField)
+      } else {
+        val includedFields = compiledFields.filter {
+          !it.shouldSkip(variableValues = variables.valueMap)
+        }
+        if (includedFields.isEmpty()) {
+          // If the field is absent, we don't want to serialize "null" to the cache, do not include this field in the record.
+          return@mapNotNull null
+        }
+        mergedField = includedFields.first().newBuilder()
+            .selections(includedFields.flatMap { it.selections })
+            .condition(emptyList())
+            .build()
+        fieldKey = fieldKeyGenerator.getFieldKey(FieldKeyContext(parentType.name, mergedField, variables))
       }
-      if (includedFields.isEmpty()) {
-        // If the field is absent, we don't want to serialize "null" to the cache, do not include this field in the record.
-        return@mapNotNull null
-      }
-      val mergedField = includedFields.first().newBuilder()
-          .selections(includedFields.flatMap { it.selections })
-          .condition(emptyList())
-          .build()
-
-      val fieldKey = fieldKeyGenerator.getFieldKey(FieldKeyContext(parentType.name, mergedField, variables))
 
       val base = if (key == CacheKey.QUERY_ROOT) {
         // If we're at the query root level, skip `QUERY_ROOT` altogether to save a few bytes.
@@ -244,14 +279,16 @@ internal class Normalizer(
   }
 
   private class CollectState {
-    val fields = mutableListOf<CompiledField>()
+    val fields = mutableMapOf<String, MutableList<CompiledField>>()
   }
 
   private fun collectFields(selections: List<CompiledSelection>, parentType: String, typename: String?, state: CollectState) {
     selections.forEach {
       when (it) {
         is CompiledField -> {
-          state.fields.add(it)
+          // Most response names are selected once, so the lists start at that size rather than at
+          // `ArrayList`'s default of 10.
+          state.fields.getOrPut(it.responseName) { ArrayList(1) }.add(it)
         }
 
         is CompiledFragment -> {
@@ -264,11 +301,15 @@ internal class Normalizer(
   }
 
   /**
+   * The fields selected on the object, indexed by response name. Indexing them as they are collected
+   * costs no more than the flat list this used to return and saves scanning that list once per key of
+   * the object being normalized.
+   *
    * @param typename the typename of the object. It might be null if the `__typename` field wasn't queried. If
    * that's the case, we will collect less fields than we should and records will miss some values leading to more
    * cache miss
    */
-  private fun collectFields(selections: List<CompiledSelection>, parentType: String, typename: String?): List<CompiledField> {
+  private fun collectFields(selections: List<CompiledSelection>, parentType: String, typename: String?): Map<String, List<CompiledField>> {
     val state = CollectState()
     collectFields(selections, parentType, typename, state)
     return state.fields

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
@@ -24,6 +24,7 @@ import com.apollographql.cache.normalized.api.EmptyEmbeddedFieldsProvider
 import com.apollographql.cache.normalized.api.EmptyMetadataGenerator
 import com.apollographql.cache.normalized.api.FieldKeyContext
 import com.apollographql.cache.normalized.api.FieldKeyGenerator
+import com.apollographql.cache.normalized.api.GlobalMaxAgeProvider
 import com.apollographql.cache.normalized.api.MaxAgeContext
 import com.apollographql.cache.normalized.api.MaxAgeProvider
 import com.apollographql.cache.normalized.api.MetadataGenerator
@@ -48,6 +49,18 @@ internal class Normalizer(
     private val maxAgeProvider: MaxAgeProvider,
 ) {
   private val records = mutableMapOf<CacheKey, Record>()
+
+  /**
+   * The max age of every field, when [maxAgeProvider] gives them all the same one - which is what
+   * [DefaultMaxAgeProvider] does, so this is the usual case. The provider then ignores the field path,
+   * and the path is not built at all: it holds a [MaxAgeContext.Field] per level, each of which walks
+   * its type's interface hierarchy.
+   */
+  private val globalMaxAge: Duration? = if (maxAgeProvider is GlobalMaxAgeProvider) {
+    maxAgeProvider.getMaxAge(MaxAgeContext(emptyList()))
+  } else {
+    null
+  }
 
   /**
    * Field keys, indexed by parent type name then by field. Computing one encodes the field's arguments
@@ -155,7 +168,7 @@ internal class Normalizer(
           path = base?.append(fieldKey) ?: CacheKey(fieldKey),
           isEmbedded = embeddedFieldsProvider.isEmbedded(EmbeddedFieldsContext(obj = obj, parentType = parentType, field = mergedField)),
       )
-      val maxAge = maxAgeProvider.getMaxAge(MaxAgeContext(newFieldPath.map { it.toMaxAgeField() }))
+      val maxAge = globalMaxAge ?: maxAgeProvider.getMaxAge(MaxAgeContext(newFieldPath.map { it.toMaxAgeField() }))
       if (maxAge == Duration.ZERO) {
         // This field should not be stored, do not include it in the record.
         return@mapNotNull null

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
@@ -123,11 +123,7 @@ internal class Normalizer(
         // For all cache purposes, this is not part of the response and we therefore do not include this in the response
         return@mapNotNull null
       }
-      // A lone field with no condition to clear is already the result of merging its group, so it is
-      // normalized as is: rebuilding it would allocate a copy equal to it, once per object. It is also
-      // then the same instance for every object normalized against these selections, which is what
-      // makes its field key worth memoizing - a merged field is a new instance every time, so keeping
-      // its key would only retain the copy.
+      // A lone field with no condition to clear is already the result of merging its group, so it is normalized as is.
       val sharedField = compiledFields.singleOrNull()?.takeIf { it.condition.isEmpty() }
       val mergedField: CompiledField
       val fieldKey: String
@@ -314,9 +310,7 @@ internal class Normalizer(
   }
 
   /**
-   * The fields selected on the object, indexed by response name. Indexing them as they are collected
-   * costs no more than the flat list this used to return and saves scanning that list once per key of
-   * the object being normalized.
+   * The fields selected on the object, indexed by response name.
    *
    * @param typename the typename of the object. It might be null if the `__typename` field wasn't queried. If
    * that's the case, we will collect less fields than we should and records will miss some values leading to more

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/OptimisticNormalizedCache.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/OptimisticNormalizedCache.kt
@@ -77,9 +77,11 @@ internal class OptimisticNormalizedCache(
   }
 
   fun addOptimisticUpdates(recordSet: Collection<Record>): Set<String> {
-    return recordSet.flatMap {
-      addOptimisticUpdate(it)
-    }.toSet()
+    return buildSet {
+      for (record in recordSet) {
+        addAll(addOptimisticUpdate(record))
+      }
+    }
   }
 
   fun addOptimisticUpdate(record: Record): Set<String> {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
@@ -122,8 +122,6 @@ class MemoryCache(
     return withLock {
       val existingRecords = loadRecords(records.map { it.key }, cacheHeaders).associateBy { it.key }
       val recordsToInsert = mutableListOf<Record>()
-      // Accumulated in one pass: `flatMap {}.toSet()` would materialize every changed field key of
-      // every record in a list before building the set that is actually returned.
       val changedKeys = mutableSetOf<String>()
       for (incoming in records) {
         val record = incoming.withDates(receivedDate = receivedDate, expirationDate = expirationDate)

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/memory/MemoryCache.kt
@@ -8,6 +8,7 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.api.RecordMerger
 import com.apollographql.cache.normalized.api.RecordMergerContext
+import com.apollographql.cache.normalized.api.fieldKey
 import com.apollographql.cache.normalized.api.withDates
 import com.apollographql.cache.normalized.api.withSizeInBytes
 import com.apollographql.cache.normalized.internal.withReentrantLock
@@ -121,22 +122,27 @@ class MemoryCache(
     return withLock {
       val existingRecords = loadRecords(records.map { it.key }, cacheHeaders).associateBy { it.key }
       val recordsToInsert = mutableListOf<Record>()
-      val changedKeys = records.flatMap { record ->
-        val record = record.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
+      // Accumulated in one pass: `flatMap {}.toSet()` would materialize every changed field key of
+      // every record in a list before building the set that is actually returned.
+      val changedKeys = mutableSetOf<String>()
+      for (incoming in records) {
+        val record = incoming.withDates(receivedDate = receivedDate, expirationDate = expirationDate)
         val existingRecord = existingRecords[record.key]
         if (existingRecord == null) {
           recordsToInsert.add(record)
           lruCache[record.key] = record
-          record.fieldKeys()
+          for (fieldName in record.fields.keys) {
+            changedKeys.add(record.key.fieldKey(fieldName))
+          }
         } else {
-          val (mergedRecord, changedKeys) = recordMerger.merge(RecordMergerContext(existing = existingRecord, incoming = record, cacheHeaders = cacheHeaders))
+          val (mergedRecord, recordChangedKeys) = recordMerger.merge(RecordMergerContext(existing = existingRecord, incoming = record, cacheHeaders = cacheHeaders))
           if (mergedRecord != existingRecord) {
             recordsToInsert.add(mergedRecord)
             lruCache[record.key] = mergedRecord
           }
-          changedKeys
+          changedKeys.addAll(recordChangedKeys)
         }
-      }.toSet()
+      }
       nextCache?.merge(
           records = recordsToInsert,
           cacheHeaders = cacheHeaders.newBuilder()

--- a/normalized-cache/src/commonTest/kotlin/com/apollographql/cache/normalized/DefaultRecordMergerTest.kt
+++ b/normalized-cache/src/commonTest/kotlin/com/apollographql/cache/normalized/DefaultRecordMergerTest.kt
@@ -1,12 +1,18 @@
 package com.apollographql.cache.normalized
 
+import com.apollographql.apollo.api.Error
+import com.apollographql.cache.normalized.api.ApolloCacheHeaders
 import com.apollographql.cache.normalized.api.CacheHeaders
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.DefaultRecordMerger
+import com.apollographql.cache.normalized.api.FieldRecordMerger
 import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.api.RecordMergerContext
+import com.apollographql.cache.normalized.api.fieldKey
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 
 class DefaultRecordMergerTest {
   @Test
@@ -78,5 +84,200 @@ class DefaultRecordMergerTest {
 
     assertEquals(expected.fields, mergedRecord.fields)
     assertEquals(expected.metadata, mergedRecord.metadata)
+  }
+
+  @Test
+  fun mergeNoMetadata() {
+    val existing = Record(key = CacheKey("key"), fields = mapOf("field1" to "value1"))
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field2" to "value2"))
+
+    val mergedRecord = DefaultRecordMerger.merge(RecordMergerContext(existing, incoming, CacheHeaders.NONE)).first
+
+    assertEquals(mapOf("field1" to "value1", "field2" to "value2"), mergedRecord.fields)
+    assertEquals(emptyMap(), mergedRecord.metadata)
+  }
+
+  @Test
+  fun mergeMetadataOnOneSideOnly() {
+    val metadata = mapOf("field1" to mapOf("meta1" to "metaValue1"))
+
+    val existingHasIt = DefaultRecordMerger.merge(
+        RecordMergerContext(
+            existing = Record(key = CacheKey("key"), fields = mapOf("field1" to "value1"), metadata = metadata),
+            incoming = Record(key = CacheKey("key"), fields = mapOf("field2" to "value2")),
+            cacheHeaders = CacheHeaders.NONE,
+        ),
+    ).first
+    assertEquals(metadata, existingHasIt.metadata)
+
+    val incomingHasIt = DefaultRecordMerger.merge(
+        RecordMergerContext(
+            existing = Record(key = CacheKey("key"), fields = mapOf("field2" to "value2")),
+            incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to "value1"), metadata = metadata),
+            cacheHeaders = CacheHeaders.NONE,
+        ),
+    ).first
+    assertEquals(metadata, incomingHasIt.metadata)
+  }
+
+  /**
+   * A cached `null` is a value like any other: an incoming error must not replace it unless
+   * [ApolloCacheHeaders.ERRORS_REPLACE_CACHED_VALUES] says so. `null` is also the value a lookup
+   * returns for an absent field, which is what makes this worth pinning down.
+   */
+  @Test
+  fun incomingErrorDoesNotReplaceCachedNull() {
+    val existing = Record(key = CacheKey("key"), fields = mapOf("field1" to null))
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to Error.Builder("boom").build()))
+
+    val (mergedRecord, changedKeys) = DefaultRecordMerger.merge(RecordMergerContext(existing, incoming, CacheHeaders.NONE))
+
+    assertEquals(mapOf("field1" to null), mergedRecord.fields)
+    assertEquals(emptySet(), changedKeys)
+  }
+
+  @Test
+  fun incomingErrorReplacesCachedNullWhenHeaderIsSet() {
+    val error = Error.Builder("boom").build()
+    val existing = Record(key = CacheKey("key"), fields = mapOf("field1" to null))
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to error))
+
+    val (mergedRecord, changedKeys) = DefaultRecordMerger.merge(
+        RecordMergerContext(
+            existing = existing,
+            incoming = incoming,
+            cacheHeaders = CacheHeaders.builder().addHeader(ApolloCacheHeaders.ERRORS_REPLACE_CACHED_VALUES, "true").build(),
+        ),
+    )
+
+    assertEquals(mapOf("field1" to error), mergedRecord.fields)
+    assertEquals(setOf(CacheKey("key").fieldKey("field1")), changedKeys)
+  }
+
+  /**
+   * Nothing is cached for the field, so the incoming error is what the cache learns about it.
+   */
+  @Test
+  fun incomingErrorIsStoredForAnAbsentField() {
+    val error = Error.Builder("boom").build()
+    val existing = Record(key = CacheKey("key"), fields = emptyMap())
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to error))
+
+    val (mergedRecord, changedKeys) = DefaultRecordMerger.merge(RecordMergerContext(existing, incoming, CacheHeaders.NONE))
+
+    assertEquals(mapOf("field1" to error), mergedRecord.fields)
+    assertEquals(setOf(CacheKey("key").fieldKey("field1")), changedKeys)
+  }
+
+  @Test
+  fun mergingNullOverNullDoesNotReportAChange() {
+    val existing = Record(key = CacheKey("key"), fields = mapOf("field1" to null))
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to null))
+
+    val (mergedRecord, changedKeys) = DefaultRecordMerger.merge(RecordMergerContext(existing, incoming, CacheHeaders.NONE))
+
+    assertEquals(mapOf("field1" to null), mergedRecord.fields)
+    assertEquals(emptySet(), changedKeys)
+  }
+
+  /**
+   * An incoming `null` for a field that was absent is new information, so it is a change even though
+   * both a lookup of the existing field and the incoming value are `null`.
+   */
+  @Test
+  fun mergingNullOverAnAbsentFieldReportsAChange() {
+    val existing = Record(key = CacheKey("key"), fields = emptyMap())
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to null))
+
+    val (mergedRecord, changedKeys) = DefaultRecordMerger.merge(RecordMergerContext(existing, incoming, CacheHeaders.NONE))
+
+    assertEquals(mapOf("field1" to null), mergedRecord.fields)
+    assertEquals(setOf(CacheKey("key").fieldKey("field1")), changedKeys)
+  }
+
+  /**
+   * [FieldRecordMerger] separates "absent" from "present" to decide whether to call its [FieldRecordMerger.FieldMerger]
+   * at all, so it gets the same treatment.
+   */
+  @Test
+  fun fieldRecordMergerIncomingErrorDoesNotReplaceCachedNull() {
+    var mergerCalled = false
+    val merger = FieldRecordMerger(
+        object : FieldRecordMerger.FieldMerger {
+          override fun mergeFields(
+              existing: FieldRecordMerger.FieldInfo,
+              incoming: FieldRecordMerger.FieldInfo,
+          ): FieldRecordMerger.FieldInfo {
+            mergerCalled = true
+            return incoming
+          }
+        },
+    )
+    val existing = Record(key = CacheKey("key"), fields = mapOf("field1" to null))
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to Error.Builder("boom").build()))
+
+    val (mergedRecord, changedKeys) = merger.merge(RecordMergerContext(existing, incoming, CacheHeaders.NONE))
+
+    assertFalse(mergerCalled)
+    assertEquals(mapOf("field1" to null), mergedRecord.fields)
+    assertEquals(emptySet(), changedKeys)
+  }
+
+  /**
+   * An existing `null` goes through the [FieldRecordMerger.FieldMerger] like any other value. Were it
+   * treated as absent, the incoming value would be taken as is and the merger never consulted.
+   */
+  @Test
+  fun fieldRecordMergerMergesAnExistingNull() {
+    var seen: Pair<FieldRecordMerger.FieldInfo, FieldRecordMerger.FieldInfo>? = null
+    val merger = FieldRecordMerger(
+        object : FieldRecordMerger.FieldMerger {
+          override fun mergeFields(
+              existing: FieldRecordMerger.FieldInfo,
+              incoming: FieldRecordMerger.FieldInfo,
+          ): FieldRecordMerger.FieldInfo {
+            seen = existing to incoming
+            // Keep the existing null, which the "absent" path could not have done.
+            return existing
+          }
+        },
+    )
+    val existing = Record(key = CacheKey("key"), fields = mapOf("field1" to null))
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to "value1"))
+
+    val (mergedRecord, changedKeys) = merger.merge(RecordMergerContext(existing, incoming, CacheHeaders.NONE))
+
+    assertNotNull(seen)
+    assertEquals(null, seen.first.value)
+    assertEquals("value1", seen.second.value)
+    assertEquals(mapOf("field1" to null), mergedRecord.fields)
+    assertEquals(setOf(CacheKey("key").fieldKey("field1")), changedKeys)
+  }
+
+  /**
+   * A field absent from the existing record is taken as is: there is nothing to merge it with.
+   */
+  @Test
+  fun fieldRecordMergerDoesNotMergeAnAbsentField() {
+    var mergerCalled = false
+    val merger = FieldRecordMerger(
+        object : FieldRecordMerger.FieldMerger {
+          override fun mergeFields(
+              existing: FieldRecordMerger.FieldInfo,
+              incoming: FieldRecordMerger.FieldInfo,
+          ): FieldRecordMerger.FieldInfo {
+            mergerCalled = true
+            return incoming
+          }
+        },
+    )
+    val existing = Record(key = CacheKey("key"), fields = emptyMap())
+    val incoming = Record(key = CacheKey("key"), fields = mapOf("field1" to null))
+
+    val (mergedRecord, changedKeys) = merger.merge(RecordMergerContext(existing, incoming, CacheHeaders.NONE))
+
+    assertFalse(mergerCalled)
+    assertEquals(mapOf("field1" to null), mergedRecord.fields)
+    assertEquals(setOf(CacheKey("key").fieldKey("field1")), changedKeys)
   }
 }

--- a/normalized-cache/src/commonTest/kotlin/com/apollographql/cache/normalized/RecordChangedKeysTest.kt
+++ b/normalized-cache/src/commonTest/kotlin/com/apollographql/cache/normalized/RecordChangedKeysTest.kt
@@ -5,7 +5,6 @@ import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.api.fieldKey
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 /**
  * [Record.Companion.changedKeys] tells [com.apollographql.cache.normalized.internal.OptimisticNormalizedCache]
@@ -135,15 +134,5 @@ class RecordChangedKeysTest {
             mapOf("same" to "s", "differing" to "b", "onlyIn2" to null),
         ),
     )
-  }
-
-  @Test
-  fun differentKeysAreRejected() {
-    assertFailsWith<IllegalStateException> {
-      Record.changedKeys(
-          Record(key = CacheKey("User:1"), fields = emptyMap()),
-          Record(key = CacheKey("User:2"), fields = emptyMap()),
-      )
-    }
   }
 }

--- a/normalized-cache/src/commonTest/kotlin/com/apollographql/cache/normalized/RecordChangedKeysTest.kt
+++ b/normalized-cache/src/commonTest/kotlin/com/apollographql/cache/normalized/RecordChangedKeysTest.kt
@@ -1,0 +1,149 @@
+package com.apollographql.cache.normalized
+
+import com.apollographql.cache.normalized.api.CacheKey
+import com.apollographql.cache.normalized.api.Record
+import com.apollographql.cache.normalized.api.fieldKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * [Record.Companion.changedKeys] tells [com.apollographql.cache.normalized.internal.OptimisticNormalizedCache]
+ * which watchers to notify when an optimistic update is rolled back, so a key it fails to report is a
+ * watcher that never refreshes.
+ *
+ * A `null` field value is what makes this subtle: it is indistinguishable from an absent field by
+ * lookup alone, so these tests pin down every combination of absent / null / non-null on both sides.
+ */
+class RecordChangedKeysTest {
+  private val key = CacheKey("User:1")
+
+  private fun changedKeys(fields1: Map<String, Any?>, fields2: Map<String, Any?>): Set<String> {
+    return Record.changedKeys(
+        Record(key = key, fields = fields1),
+        Record(key = key, fields = fields2),
+    )
+  }
+
+  @Test
+  fun sameFieldsAreNotChanged() {
+    assertEquals(
+        emptySet(),
+        changedKeys(
+            mapOf("name" to "John", "age" to 42),
+            mapOf("name" to "John", "age" to 42),
+        ),
+    )
+  }
+
+  @Test
+  fun differentValueIsChanged() {
+    assertEquals(
+        setOf(key.fieldKey("name")),
+        changedKeys(
+            mapOf("name" to "John", "age" to 42),
+            mapOf("name" to "Jane", "age" to 42),
+        ),
+    )
+  }
+
+  @Test
+  fun fieldOnlyInFirstRecordIsChanged() {
+    assertEquals(
+        setOf(key.fieldKey("age")),
+        changedKeys(
+            mapOf("name" to "John", "age" to 42),
+            mapOf("name" to "John"),
+        ),
+    )
+  }
+
+  @Test
+  fun fieldOnlyInSecondRecordIsChanged() {
+    assertEquals(
+        setOf(key.fieldKey("age")),
+        changedKeys(
+            mapOf("name" to "John"),
+            mapOf("name" to "John", "age" to 42),
+        ),
+    )
+  }
+
+  @Test
+  fun nullInBothRecordsIsNotChanged() {
+    assertEquals(
+        emptySet(),
+        changedKeys(
+            mapOf("name" to null),
+            mapOf("name" to null),
+        ),
+    )
+  }
+
+  @Test
+  fun nullInFirstRecordAndAbsentFromSecondIsChanged() {
+    // The ambiguous case: `fields2["name"]` is null either way, so only `containsKey` separates a
+    // field that was removed from one that is still there and null.
+    assertEquals(
+        setOf(key.fieldKey("name")),
+        changedKeys(
+            mapOf("name" to null),
+            emptyMap(),
+        ),
+    )
+  }
+
+  @Test
+  fun absentFromFirstRecordAndNullInSecondIsChanged() {
+    assertEquals(
+        setOf(key.fieldKey("name")),
+        changedKeys(
+            emptyMap(),
+            mapOf("name" to null),
+        ),
+    )
+  }
+
+  @Test
+  fun nullToNonNullIsChanged() {
+    assertEquals(
+        setOf(key.fieldKey("name")),
+        changedKeys(
+            mapOf("name" to null),
+            mapOf("name" to "John"),
+        ),
+    )
+  }
+
+  @Test
+  fun nonNullToNullIsChanged() {
+    assertEquals(
+        setOf(key.fieldKey("name")),
+        changedKeys(
+            mapOf("name" to "John"),
+            mapOf("name" to null),
+        ),
+    )
+  }
+
+  @Test
+  fun changesOnBothSidesAreAllReported() {
+    assertEquals(
+        setOf(key.fieldKey("onlyIn1"), key.fieldKey("onlyIn2"), key.fieldKey("differing")),
+        changedKeys(
+            mapOf("same" to "s", "differing" to "a", "onlyIn1" to null),
+            mapOf("same" to "s", "differing" to "b", "onlyIn2" to null),
+        ),
+    )
+  }
+
+  @Test
+  fun differentKeysAreRejected() {
+    assertFailsWith<IllegalStateException> {
+      Record.changedKeys(
+          Record(key = CacheKey("User:1"), fields = emptyMap()),
+          Record(key = CacheKey("User:2"), fields = emptyMap()),
+      )
+    }
+  }
+}

--- a/tests/cache-control/src/commonTest/kotlin/MaxAgeFieldPathTest.kt
+++ b/tests/cache-control/src/commonTest/kotlin/MaxAgeFieldPathTest.kt
@@ -1,0 +1,154 @@
+package test
+
+import com.apollographql.apollo.exception.CacheMissException
+import com.apollographql.cache.normalized.CacheManager
+import com.apollographql.cache.normalized.api.CacheControlCacheResolver
+import com.apollographql.cache.normalized.api.CacheKey
+import com.apollographql.cache.normalized.api.DefaultCacheKeyGenerator
+import com.apollographql.cache.normalized.api.DefaultCacheResolver
+import com.apollographql.cache.normalized.api.DefaultMaxAgeProvider
+import com.apollographql.cache.normalized.api.GlobalMaxAgeProvider
+import com.apollographql.cache.normalized.api.MaxAgeContext
+import com.apollographql.cache.normalized.api.MaxAgeProvider
+import com.apollographql.cache.normalized.internal.normalized
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
+import programmatic.GetReaderBookTitleQuery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A [GlobalMaxAgeProvider] gives every field the same max age and never reads the field path, so both
+ * callers resolve it once and skip building the path. Any other provider has to be handed the whole
+ * path, root first, exactly as before.
+ */
+class MaxAgeFieldPathTest {
+  /**
+   * Records the path it is asked about, and answers a fixed max age without delegating - a delegating
+   * recorder would also record the sub-paths its delegate walks, and what is under test here is the
+   * path the caller builds.
+   */
+  private class RecordingMaxAgeProvider(private val maxAge: Duration) : MaxAgeProvider {
+    val paths = mutableListOf<List<String>>()
+
+    override fun getMaxAge(maxAgeContext: MaxAgeContext): Duration {
+      paths.add(maxAgeContext.fieldPath.map { "${it.type.name}.${it.name}" })
+      return maxAge
+    }
+  }
+
+  @Test
+  fun normalizingHandsTheWholeFieldPathToANonGlobalProvider() = runTest {
+    val provider = RecordingMaxAgeProvider(60.seconds)
+
+    readerBookTitleData().normalized(
+        GetReaderBookTitleQuery(),
+        DefaultCacheKeyGenerator,
+        maxAgeProvider = provider,
+    )
+
+    // Deepest first: the normalizer replaces a field's value, which normalizes everything under it,
+    // before asking for that field's max age.
+    assertEquals(
+        listOf(
+            listOf("Query.data", "Reader.reader", "Book.book", "String.title"),
+            listOf("Query.data", "Reader.reader", "Book.book"),
+            listOf("Query.data", "Reader.reader"),
+        ),
+        provider.paths,
+    )
+  }
+
+  @Test
+  fun readingHandsTheWholeFieldPathToANonGlobalProvider() = runTest {
+    val provider = RecordingMaxAgeProvider(60.seconds)
+    val cacheManager = CacheManager(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyGenerator = DefaultCacheKeyGenerator,
+        cacheResolver = CacheControlCacheResolver(provider, DefaultCacheResolver),
+    )
+    val query = GetReaderBookTitleQuery()
+
+    // The resolver only looks at the max age of a field it knows the received date of.
+    cacheManager.writeOperation(query, readerBookTitleData(), cacheHeaders = receivedDate(currentTimeSeconds()))
+    provider.paths.clear()
+
+    assertEquals("Le Petit Prince", cacheManager.readOperation(query).data?.reader?.book?.title)
+
+    assertEquals(
+        listOf(
+            listOf("Query.data", "Reader.reader"),
+            listOf("Query.data", "Reader.reader", "Book.book"),
+            listOf("Query.data", "Reader.reader", "Book.book", "String.title"),
+        ),
+        provider.paths,
+    )
+  }
+
+  /**
+   * The short-circuit has to answer what the provider would have answered: a max age of zero means the
+   * field is not stored at all.
+   */
+  @Test
+  fun aGlobalMaxAgeOfZeroStoresNothing() = runTest {
+    val records = readerBookTitleData().normalized(
+        GetReaderBookTitleQuery(),
+        DefaultCacheKeyGenerator,
+        maxAgeProvider = GlobalMaxAgeProvider(Duration.ZERO),
+    )
+
+    assertEquals(emptyMap(), records[CacheKey.QUERY_ROOT]?.fields ?: emptyMap())
+  }
+
+  @Test
+  fun anInfiniteGlobalMaxAgeStoresEverything() = runTest {
+    val records = readerBookTitleData().normalized(
+        GetReaderBookTitleQuery(),
+        DefaultCacheKeyGenerator,
+        maxAgeProvider = DefaultMaxAgeProvider,
+    )
+
+    assertTrue(records.getValue(CacheKey.QUERY_ROOT).fields.containsKey("reader"))
+  }
+
+  @Test
+  fun aGlobalMaxAgeOfZeroMakesEveryReadFieldStale() = runTest {
+    val cacheManager = CacheManager(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyGenerator = DefaultCacheKeyGenerator,
+        cacheResolver = CacheControlCacheResolver(GlobalMaxAgeProvider(Duration.ZERO), DefaultCacheResolver),
+    )
+    val query = GetReaderBookTitleQuery()
+
+    // Written with the default provider, so the records exist and carry a received date.
+    cacheManager.writeOperation(query, readerBookTitleData(), cacheHeaders = receivedDate(currentTimeSeconds()))
+
+    val exception = cacheManager.readOperation(query).exception
+    assertIs<CacheMissException>(exception)
+    assertTrue(exception.stale)
+  }
+
+  @Test
+  fun anInfiniteGlobalMaxAgeMakesNoReadFieldStale() = runTest {
+    val cacheManager = CacheManager(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyGenerator = DefaultCacheKeyGenerator,
+        cacheResolver = CacheControlCacheResolver(DefaultMaxAgeProvider, DefaultCacheResolver),
+    )
+    val query = GetReaderBookTitleQuery()
+
+    cacheManager.writeOperation(query, readerBookTitleData(), cacheHeaders = receivedDate(currentTimeSeconds()))
+
+    assertEquals("Le Petit Prince", cacheManager.readOperation(query).data?.reader?.book?.title)
+  }
+
+  private fun readerBookTitleData() = GetReaderBookTitleQuery.Data(
+      reader = GetReaderBookTitleQuery.Reader(
+          book = GetReaderBookTitleQuery.Book(title = "Le Petit Prince"),
+      ),
+  )
+}

--- a/tests/cache-variables-arguments/src/commonMain/graphql/operation.graphql
+++ b/tests/cache-variables-arguments/src/commonMain/graphql/operation.graphql
@@ -49,3 +49,42 @@ query TwoFields($details: Boolean!) {
   ...userId
   ...userName
 }
+
+# The only selection of `user` carries a condition, so it is not shared with anything: it must still
+# be normalized with its condition cleared, like a field merged out of several selections.
+query LoneConditionalField($details: Boolean!) {
+  user @include(if: $details) {
+    id
+    name
+  }
+}
+
+# Both selections of `user` carry the same condition, so they merge into one field.
+query TwoConditionalFields($details: Boolean!) {
+  user @include(if: $details) {
+    id
+  }
+  user @include(if: $details) {
+    name
+  }
+}
+
+# A field with arguments, selected on every object of a list: its key is the same for all of them.
+query UsersWithAvatars($size: Int!) {
+  users {
+    id
+    avatar(size: $size)
+  }
+}
+
+# `id` and `name` are selected on two different parent types.
+query UserAndCompany {
+  user {
+    id
+    name
+  }
+  company {
+    id
+    name
+  }
+}

--- a/tests/cache-variables-arguments/src/commonMain/graphql/schema.graphqls
+++ b/tests/cache-variables-arguments/src/commonMain/graphql/schema.graphqls
@@ -1,5 +1,7 @@
 type Query {
   user: User!
+  users: [User!]!
+  company: Company!
   a0(b: B): Int
   a1(b: B = {}): Int
   a2(b: B = {c: 2}): Int
@@ -14,4 +16,10 @@ type User {
   id: ID!
   name: String!
   email: String!
+  avatar(size: Int!): String!
+}
+
+type Company {
+  id: ID!
+  name: String!
 }

--- a/tests/cache-variables-arguments/src/commonTest/kotlin/test/NormalizerFieldMergingTest.kt
+++ b/tests/cache-variables-arguments/src/commonTest/kotlin/test/NormalizerFieldMergingTest.kt
@@ -1,0 +1,294 @@
+package test
+
+import cache.include.LoneConditionalFieldQuery
+import cache.include.TwoConditionalFieldsQuery
+import cache.include.TwoFieldsQuery
+import cache.include.UserAndCompanyQuery
+import cache.include.UsersWithAvatarsQuery
+import cache.include.fragment.UserId
+import cache.include.fragment.UserName
+import com.apollographql.cache.normalized.CacheManager
+import com.apollographql.cache.normalized.api.CacheHeaders
+import com.apollographql.cache.normalized.api.CacheKey
+import com.apollographql.cache.normalized.api.DefaultCacheKeyGenerator
+import com.apollographql.cache.normalized.api.DefaultCacheResolver
+import com.apollographql.cache.normalized.api.DefaultFieldKeyGenerator
+import com.apollographql.cache.normalized.api.FieldKeyContext
+import com.apollographql.cache.normalized.api.FieldKeyGenerator
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The normalizer merges the selections that share a response name into a single field, and reuses the
+ * selection as is when it is the only one - a field that is already its own merge result. These tests
+ * pin down what that reuse must preserve:
+ *
+ * - the field the normalizer hands to a [FieldKeyGenerator] never carries a condition, whether it was
+ *   merged out of several selections or reused as the only one;
+ * - a field key is generated once per field of a parent type, not once per object normalized against
+ *   it.
+ */
+class NormalizerFieldMergingTest {
+  private data class Call(
+      val parentType: String,
+      val responseName: String,
+      val hasCondition: Boolean,
+  )
+
+  /**
+   * Records every field it is asked about, and whether that field still carried a condition.
+   *
+   * The two paths differ here, so the assertion is left to each test rather than made here: see
+   * [readingBackAConditionalFieldKeepsItsCondition].
+   */
+  private class RecordingFieldKeyGenerator : FieldKeyGenerator {
+    val calls = mutableListOf<Call>()
+
+    override fun getFieldKey(context: FieldKeyContext): String {
+      calls.add(Call(context.parentType, context.field.responseName, context.field.condition.isNotEmpty()))
+      return DefaultFieldKeyGenerator.getFieldKey(context)
+    }
+  }
+
+  /**
+   * Takes a snapshot of what was recorded and clears the log, so a later read does not show up in the
+   * assertions about normalizing.
+   */
+  private fun RecordingFieldKeyGenerator.drain(): List<Call> = calls.toList().also { calls.clear() }
+
+  private fun List<Call>.names() = map { it.parentType to it.responseName }
+
+  private fun List<Call>.assertNoConditions() {
+    val conditional = filter { it.hasCondition }
+    assertTrue(
+        conditional.isEmpty(),
+        "Normalized fields were passed to the FieldKeyGenerator with a condition: " +
+            conditional.joinToString { "${it.parentType}.${it.responseName}" },
+    )
+  }
+
+  private fun cacheManager(fieldKeyGenerator: FieldKeyGenerator) = CacheManager(
+      normalizedCacheFactory = MemoryCacheFactory(),
+      cacheKeyGenerator = DefaultCacheKeyGenerator,
+      cacheResolver = DefaultCacheResolver,
+      fieldKeyGenerator = fieldKeyGenerator,
+  )
+
+  /**
+   * `user` is selected once and conditionally, so the normalizer reuses that selection instead of
+   * building a merged field from it. The condition must be cleared all the same.
+   */
+  @Test
+  fun loneConditionalFieldIsNormalizedWithoutItsCondition() = runTest {
+    val generator = RecordingFieldKeyGenerator()
+    val cacheManager = cacheManager(generator)
+    val operation = LoneConditionalFieldQuery(details = true)
+
+    cacheManager.writeOperation(
+        operation,
+        LoneConditionalFieldQuery.Data(user = LoneConditionalFieldQuery.User(id = "42", name = "John")),
+    )
+
+    val normalizing = generator.drain()
+    normalizing.assertNoConditions()
+    assertTrue(normalizing.names().contains("Query" to "user"))
+
+    val data = cacheManager.readOperation(operation).data!!
+    assertEquals("42", data.user?.id)
+    assertEquals("John", data.user?.name)
+  }
+
+  @Test
+  fun loneConditionalFieldIsNotStoredWhenSkipped() = runTest {
+    val cacheManager = cacheManager(RecordingFieldKeyGenerator())
+
+    cacheManager.writeOperation(LoneConditionalFieldQuery(details = false), LoneConditionalFieldQuery.Data(user = null))
+
+    // The field was skipped, so nothing was stored for it - not even a null.
+    val record = cacheManager.accessCache { it.loadRecord(CacheKey.QUERY_ROOT, CacheHeaders.NONE) }
+    assertEquals(emptyMap(), record?.fields ?: emptyMap())
+  }
+
+  @Test
+  fun twoSelectionsSharingAConditionAreMerged() = runTest {
+    val generator = RecordingFieldKeyGenerator()
+    val cacheManager = cacheManager(generator)
+    val operation = TwoConditionalFieldsQuery(details = true)
+
+    cacheManager.writeOperation(
+        operation,
+        TwoConditionalFieldsQuery.Data(user = TwoConditionalFieldsQuery.User(id = "42", name = "John")),
+    )
+
+    val normalizing = generator.drain()
+    normalizing.assertNoConditions()
+    // One merged field, so `user` is asked about once even though it was selected twice.
+    assertEquals(1, normalizing.names().count { it == "Query" to "user" })
+
+    val data = cacheManager.readOperation(operation).data!!
+    assertEquals("42", data.user?.id)
+    assertEquals("John", data.user?.name)
+  }
+
+  /**
+   * `user` is selected twice, once unconditionally and once with a condition, so the two selections
+   * merge into one field.
+   */
+  @Test
+  fun selectionsWithDifferentConditionsAreMerged() = runTest {
+    val generator = RecordingFieldKeyGenerator()
+    val cacheManager = cacheManager(generator)
+    val operation = TwoFieldsQuery(details = true)
+
+    cacheManager.writeOperation(
+        operation,
+        TwoFieldsQuery.Data(
+            __typename = "Query",
+            userId = UserId(UserId.User("42")),
+            userName = UserName(user = UserName.User("John")),
+        ),
+    )
+
+    val normalizing = generator.drain()
+    normalizing.assertNoConditions()
+    assertEquals(1, normalizing.names().count { it == "Query" to "user" })
+
+    val data = cacheManager.readOperation(operation).data!!
+    assertEquals("42", data.userId.user.id)
+    assertEquals("John", data.userName.user?.name)
+  }
+
+  /**
+   * Same query with the condition evaluating the other way: only the unconditional selection of `user`
+   * is left, so the merged field is built from one selection.
+   *
+   * There is no reading back here: the two fragments share the `user` response name, and the generated
+   * adapters do not evaluate conditions, so the one belonging to the skipped selection parses whatever
+   * the other one left under that name and asks for a `name` that was never selected. That is the shape
+   * of the generated operation - a network response would run into it too - not something the cache
+   * decides. See https://github.com/apollographql/apollo-kotlin/issues/6901.
+   */
+  @Test
+  fun aSkippedSelectionLeavesTheOtherOneToMerge() = runTest {
+    val generator = RecordingFieldKeyGenerator()
+    val cacheManager = cacheManager(generator)
+
+    cacheManager.writeOperation(
+        TwoFieldsQuery(details = false),
+        TwoFieldsQuery.Data(
+            __typename = "Query",
+            userId = UserId(UserId.User("42")),
+            userName = UserName(user = null),
+        ),
+    )
+
+    val normalizing = generator.drain()
+    normalizing.assertNoConditions()
+    assertEquals(1, normalizing.names().count { it == "Query" to "user" })
+    // `name` was not selected, so no key was generated for it.
+    assertEquals(0, normalizing.names().count { it == "User" to "name" })
+  }
+
+  /**
+   * The reader merges the selections sharing a response name *and* a condition, and keeps that
+   * condition on the merged field - unlike the normalizer, which clears it. So a [FieldKeyGenerator]
+   * sees a conditional field when reading and an unconditional one when writing.
+   *
+   * That asymmetry is harmless for [DefaultFieldKeyGenerator], which keys on the response name and the
+   * arguments only, and it is not something these changes introduced. It is pinned here so that a
+   * change to either path is a deliberate one.
+   */
+  @Test
+  fun readingBackAConditionalFieldKeepsItsCondition() = runTest {
+    val generator = RecordingFieldKeyGenerator()
+    val cacheManager = cacheManager(generator)
+    val operation = LoneConditionalFieldQuery(details = true)
+
+    cacheManager.writeOperation(
+        operation,
+        LoneConditionalFieldQuery.Data(user = LoneConditionalFieldQuery.User(id = "42", name = "John")),
+    )
+    generator.drain().assertNoConditions()
+
+    cacheManager.readOperation(operation)
+
+    val reading = generator.drain()
+    assertEquals(
+        listOf(Call("Query", "user", hasCondition = true)),
+        reading.filter { it.responseName == "user" },
+    )
+  }
+
+  /**
+   * The same fields are normalized again for every object of a list, and generating a field key encodes
+   * the field's arguments to JSON. The number of keys generated must therefore not grow with the list.
+   */
+  @Test
+  fun fieldKeysAreGeneratedOncePerFieldRatherThanPerObject() = runTest {
+    fun users(count: Int) = List(count) { index ->
+      UsersWithAvatarsQuery.User(id = index.toString(), avatar = "avatar$index")
+    }
+
+    val oneUser = RecordingFieldKeyGenerator()
+    cacheManager(oneUser).writeOperation(UsersWithAvatarsQuery(size = 64), UsersWithAvatarsQuery.Data(users = users(1)))
+
+    val manyUsers = RecordingFieldKeyGenerator()
+    cacheManager(manyUsers).writeOperation(UsersWithAvatarsQuery(size = 64), UsersWithAvatarsQuery.Data(users = users(10)))
+
+    assertEquals(
+        oneUser.calls.names(),
+        manyUsers.calls.names(),
+        "Field keys were generated per object: normalizing 10 users asked for ${manyUsers.calls.size} field keys " +
+            "where one user asked for ${oneUser.calls.size}",
+    )
+    assertEquals(listOf("Query" to "users", "User" to "id", "User" to "avatar"), oneUser.calls.names())
+  }
+
+  @Test
+  fun fieldKeysCarryTheirArguments() = runTest {
+    val cacheManager = cacheManager(DefaultFieldKeyGenerator)
+    val operation = UsersWithAvatarsQuery(size = 64)
+
+    cacheManager.writeOperation(
+        operation,
+        UsersWithAvatarsQuery.Data(users = listOf(UsersWithAvatarsQuery.User(id = "1", avatar = "avatar1"))),
+    )
+
+    val data = cacheManager.readOperation(operation).data!!
+    assertEquals("avatar1", data.users.single().avatar)
+
+    // A different argument is a different field key, so it is a cache miss rather than a stale hit.
+    val otherSize = cacheManager.readOperation(UsersWithAvatarsQuery(size = 128))
+    assertEquals(null, otherSize.data?.users?.single()?.avatar)
+  }
+
+  /**
+   * Field keys are memoized per parent type, so two types that select the same field name must not
+   * share a key.
+   */
+  @Test
+  fun fieldKeysAreNotSharedAcrossParentTypes() = runTest {
+    val generator = RecordingFieldKeyGenerator()
+    val cacheManager = cacheManager(generator)
+    val operation = UserAndCompanyQuery()
+
+    cacheManager.writeOperation(
+        operation,
+        UserAndCompanyQuery.Data(
+            user = UserAndCompanyQuery.User(id = "42", name = "John"),
+            company = UserAndCompanyQuery.Company(id = "1", name = "Acme"),
+        ),
+    )
+
+    val normalizing = generator.drain().names()
+    assertEquals(1, normalizing.count { it == "User" to "id" })
+    assertEquals(1, normalizing.count { it == "Company" to "id" })
+
+    val data = cacheManager.readOperation(operation).data!!
+    assertEquals("John", data.user.name)
+    assertEquals("Acme", data.company.name)
+  }
+}

--- a/tests/partial-results/src/commonTest/kotlin/test/ResponsePathTest.kt
+++ b/tests/partial-results/src/commonTest/kotlin/test/ResponsePathTest.kt
@@ -1,0 +1,239 @@
+package test
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Error
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.api.CacheKey
+import com.apollographql.cache.normalized.api.FieldPolicyCacheResolver
+import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
+import com.apollographql.cache.normalized.apolloStore
+import com.apollographql.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.fetchPolicyInterceptor
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.assertErrorsEquals
+import com.apollographql.cache.normalized.testing.keyToString
+import com.apollographql.cache.normalized.testing.runTest
+import com.apollographql.mockserver.MockServer
+import com.apollographql.mockserver.enqueueString
+import okio.use
+import test.cache.Cache
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The reader keys the objects it reads by their response path, and the paths of one response share
+ * prefixes, so they are interned: two paths with the same segments are the same object, and appending a
+ * segment to a path is a lookup rather than a copy.
+ *
+ * A list is where that can go wrong, because its elements differ only in their last segment. These
+ * tests read lists of lists, so every object's path shares a prefix with its siblings' - at both
+ * levels - and check that each of them is read as itself and that a cache miss is reported at its own
+ * path.
+ */
+class ResponsePathTest {
+  private lateinit var mockServer: MockServer
+
+  private fun setUp() {
+    mockServer = MockServer()
+  }
+
+  private fun tearDown() {
+    mockServer.close()
+  }
+
+  @Test
+  fun objectsOfNestedListsAreReadAtTheirOwnPath() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueueString(threeProjectsResponse)
+    ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .normalizedCache(
+            MemoryCacheFactory(),
+            cacheKeyGenerator = TypePolicyCacheKeyGenerator(Cache.typePolicies),
+            cacheResolver = FieldPolicyCacheResolver(Cache.fieldPolicies),
+        )
+        .build()
+        .use { apolloClient ->
+          val networkResult = apolloClient.query(MeWithBestFriendQuery())
+              .fetchPolicy(FetchPolicy.NetworkOnly)
+              .execute()
+          assertEquals(threeProjectsData, networkResult.data)
+
+          // Read back from the cache: every project and every user has to come back where it was.
+          val cacheResult = apolloClient.query(MeWithBestFriendQuery())
+              .fetchPolicyInterceptor(PartialCacheOnlyInterceptor)
+              .execute()
+          assertEquals(threeProjectsData, cacheResult.data)
+          assertNull(cacheResult.errors)
+        }
+  }
+
+  /**
+   * Both objects that go missing are at a non-zero index, so a path built from a sibling's - or from the
+   * first one read at that level - would report the wrong one. `lead` is nullable, so the rest of the
+   * response survives and can be checked too.
+   */
+  @Test
+  fun aCacheMissInsideAListIsReportedAtItsOwnIndex() = runTest(before = { setUp() }, after = { tearDown() }) {
+    withPrimedCache { apolloClient ->
+      // The leads of the second and third projects.
+      apolloClient.apolloStore.remove(CacheKey("User:11"))
+      apolloClient.apolloStore.remove(CacheKey("User:12"))
+
+      val cacheResult = apolloClient.query(MeWithBestFriendQuery())
+          .fetchPolicyInterceptor(PartialCacheOnlyInterceptor)
+          .execute()
+
+      assertErrorsEquals(
+          listOf(
+              Error.Builder("Object '${CacheKey("User:11").keyToString()}' not found in the cache")
+                  .path(listOf("me", "projects", 1, "lead"))
+                  .build(),
+              Error.Builder("Object '${CacheKey("User:12").keyToString()}' not found in the cache")
+                  .path(listOf("me", "projects", 2, "lead"))
+                  .build(),
+          ),
+          cacheResult.errors,
+      )
+
+      // Everything else is untouched, each project's users included.
+      val projects = cacheResult.data!!.me!!.projects
+      assertEquals("Lead0", projects[0].lead!!.firstName)
+      assertNull(projects[1].lead)
+      assertNull(projects[2].lead)
+      assertEquals(
+          listOf(
+              listOf("User100", "User101"),
+              listOf("User110", "User111"),
+              listOf("User120", "User121"),
+          ),
+          projects.map { project -> project.users.map { it.firstName } },
+      )
+    }
+  }
+
+  /**
+   * The missing object is the last element of the inner list, so its path ends on a non-zero index and
+   * is the deepest of the response.
+   *
+   * `Project.users` is a non-null list of non-null users inside a non-null list of projects, itself on a
+   * non-null `me`, so the error propagates all the way to the root and there is no data left to check -
+   * only the path it is reported at, which is the point here.
+   */
+  @Test
+  fun aCacheMissAtTheDeepestPathIsReportedAtItsOwnIndex() = runTest(before = { setUp() }, after = { tearDown() }) {
+    withPrimedCache { apolloClient ->
+      apolloClient.apolloStore.remove(CacheKey("User:121"))
+
+      val cacheResult = apolloClient.query(MeWithBestFriendQuery())
+          .fetchPolicyInterceptor(PartialCacheOnlyInterceptor)
+          .execute()
+
+      assertErrorsEquals(
+          listOf(
+              Error.Builder("Object '${CacheKey("User:121").keyToString()}' not found in the cache")
+                  .path(listOf("me", "projects", 2, "users", 1))
+                  .build(),
+          ),
+          cacheResult.errors,
+      )
+      assertNull(cacheResult.data)
+    }
+  }
+
+  private suspend fun withPrimedCache(block: suspend (ApolloClient) -> Unit) {
+    mockServer.enqueueString(threeProjectsResponse)
+    ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .normalizedCache(
+            MemoryCacheFactory(),
+            cacheKeyGenerator = TypePolicyCacheKeyGenerator(Cache.typePolicies),
+            cacheResolver = FieldPolicyCacheResolver(Cache.fieldPolicies),
+        )
+        .build()
+        .use { apolloClient ->
+          apolloClient.query(MeWithBestFriendQuery()).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+          block(apolloClient)
+        }
+  }
+
+  private fun user(id: String, firstName: String) = MeWithBestFriendQuery.User(
+      __typename = "User",
+      id = id,
+      firstName = firstName,
+      lastName = "Doe",
+  )
+
+  private fun lead(id: String, firstName: String) = MeWithBestFriendQuery.Lead(
+      __typename = "User",
+      id = id,
+      firstName = firstName,
+      lastName = "Doe",
+  )
+
+  private val threeProjectsData = MeWithBestFriendQuery.Data(
+      MeWithBestFriendQuery.Me(
+          __typename = "User",
+          id = "1",
+          firstName = "John",
+          lastName = "Smith",
+          bestFriend = MeWithBestFriendQuery.BestFriend(
+              __typename = "User",
+              id = "2",
+              firstName = "Jane",
+              lastName = "Doe",
+          ),
+          projects = listOf(
+              MeWithBestFriendQuery.Project(
+                  __typename = "Project",
+                  lead = lead("10", "Lead0"),
+                  users = listOf(user("100", "User100"), user("101", "User101")),
+              ),
+              MeWithBestFriendQuery.Project(
+                  __typename = "Project",
+                  lead = lead("11", "Lead1"),
+                  users = listOf(user("110", "User110"), user("111", "User111")),
+              ),
+              MeWithBestFriendQuery.Project(
+                  __typename = "Project",
+                  lead = lead("12", "Lead2"),
+                  users = listOf(user("120", "User120"), user("121", "User121")),
+              ),
+          ),
+      ),
+  )
+}
+
+private fun userJson(id: String, firstName: String) =
+  """{"__typename": "User", "id": "$id", "firstName": "$firstName", "lastName": "Doe"}"""
+
+private fun projectJson(leadId: String, leadName: String, users: List<Pair<String, String>>) =
+  """
+  {
+    "__typename": "Project",
+    "lead": ${userJson(leadId, leadName)},
+    "users": [${users.joinToString(", ") { userJson(it.first, it.second) }}]
+  }
+  """
+
+private val threeProjectsResponse =
+  // language=JSON
+  """
+  {
+    "data": {
+      "me": {
+        "__typename": "User",
+        "id": "1",
+        "firstName": "John",
+        "lastName": "Smith",
+        "bestFriend": ${userJson("2", "Jane")},
+        "projects": [
+          ${projectJson("10", "Lead0", listOf("100" to "User100", "101" to "User101"))},
+          ${projectJson("11", "Lead1", listOf("110" to "User110", "111" to "User111"))},
+          ${projectJson("12", "Lead2", listOf("120" to "User120", "121" to "User121"))}
+        ]
+      }
+    }
+  }
+  """


### PR DESCRIPTION
# Summary

An allocation and complexity pass over the three hot paths of the normalized cache: normalizing a response (write), CacheBatchReader (read), and record serialization to/from SQLite. Everything here is behavior-preserving — no public API change, apiCheck passes with no dump regenerated.

The theme is work repeated per field per object. Several of these paths did something once per field of once per object in a list, where the result was either identical every time or reachable without building an intermediate collection at all.

Reviewers: Please review one commit at a time. Each commit message contains useful context about the smaller sets of changes.

# Write path (Normalizer)

- Index selections by response name once per object. allFields.filter { it.responseName == entry.key } was a linear scan per response key, so normalizing an object was O(fields²). Fields are now indexed into a Map<String, List<CompiledField>> as they're collected, which costs no more than the flat list it replaced.
- Stop rebuilding a field that is already its own merge result. newBuilder().selections(...).build() ran per field per object even when the merge group held a single element, where the rebuild produces a copy equal to the original.
- Memoize field keys. DefaultFieldKeyGenerator goes through CompiledField.nameWithArguments(variables), which allocates an okio Buffer + BufferedSinkJsonWriter per call (and argumentValues() allocates two ArrayLists even for a zero-argument field). A field with arguments inside a list of N objects encoded the same string N times. Keys are now memoized per parent type name, keyed on CompiledField identity.

The last two compose: memoization is only possible because the field instance is now stable across the objects of a list. Only the shared (non-rebuilt) fields are memoized — a merged field is a fresh instance per object, so caching its key would only retain the copy.

# Read path (CacheBatchReader)

- Intern the response paths the data map is keyed by. Map<List<Any>, Any> fed by path + responseName / path + index meant every lookup hashed and compared a list as long as the field's depth, and replaceCacheKeys re-walked the tree rebuilding the same lists. Replaced with a ResponsePath tree (parent pointer + segment + lazily-created children map): appending a segment is a lookup on the parent, and keying a map on a path hashes an identity. Two paths are the same node iff they have the same segments, which is what lets identity stand in for structural equality. asList() remains only to fill in the path of cache-miss errors.
- Skip merge grouping when every field has its own response name, which is the common shape. Each field is then a group of one and already its own merge result, so grouping only allocated a Pair to hash it by, plus a builder and a selection list per field per object.
- firstError() no longer allocates an ArrayDeque per field to search a value that usually has no error.
- processErrors is no longer quadratic in fields per object: fieldSelection(key) re-flattened the whole selection set with filterIsInstance + flatMap on every call. The responseName → CompiledField map is built once per object. Only on the hasErrors path, where it dominated.

# Max age

MaxAgeContext(fieldPath.map { it.toMaxAgeField() }) was built per field per object, and toMaxAgeField() recursively rebuilds a MaxAgeContext.Type tree for every interface the field's type implements. GlobalMaxAgeProvider ignores its context entirely, and DefaultMaxAgeProvider is one — so the whole tree was being built and discarded for everyone on the default configuration. An is GlobalMaxAgeProvider check hoisted to construction skips it, in both Normalizer and CacheControlCacheResolver.

Providers that do read the path are unaffected and still get the full context.

# SQLite

- Stop boxing record bytes. recordBytes.asIterable().chunked(BLOB_CHUNK_SIZE) boxed every byte into a List<Byte> and materialized all chunks before the first insert, and toByteArray() unboxed back. Now an index loop with copyOfRange. Note this only ever affected records above the 1 MiB chunk threshold — there was already a fast path below it — so this is a smaller win than the code shape suggests.
- Drop two copies per record read. buffer.write(row.record) → readByteArray() → deserialize re-wrapping in a third Buffer. deserialize now takes a BufferedSource.
- HashMap(size) on deserialize was sized so it rehashes at the 0.75 load factor; 0.until(size).map { } allocated an IntRange and iterator per list; shortenCacheKey/expandCacheKey called replaceFirst after an explicit startsWith, rescanning the prefix.

# Elsewhere

- writeOperation called .values.toSet() before cache.merge. Record.hashCode() recursively hashes fields + metadata, so this walked the entire normalized response a second time — and the values of a cache-key-keyed map are already distinct. merge takes a Collection<Record>, and writeFragment already passed .values bare.
- MemoryCache.merge / SqlNormalizedCache.merge materialized every changed field key of every record into a throwaway list before the set (flatMap {}.toSet()). Now the one-pass buildSet shape already used by dependentKeys().
- Record.changedKeys allocated an intersection, two differences, a filter, a map and a set; now one pass. Record.withDates rebuilt an identical two-entry map per field.
- DefaultRecordMerger.merge double-looked-up each field and always called existing.metadata.mergedWith(incoming.metadata) — which copies — even when both were empty.

# Correctness notes for reviewers

The one subtlety worth a close look: the Normalizer's rebuild does .condition(emptyList()), so a lone field is only reused when its condition is already empty. Reusing a field that has a condition would hand downstream consumers — a custom FieldKeyGenerator, MetadataGenerator, EmbeddedFieldsProvider, or CacheKeyGenerator — a field that differs from what they used to receive.

CacheBatchReader's rebuild does not clear the condition, so its singleton skip is unconditionally safe, and it falls back to the original groupBy when duplicate response names do exist, h preserves ordering exactly.