### PR TITLE
perf(cache): Take a watcher's dependent keys from the read that served it

### DIFF
--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheKey.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/CacheKey.kt
@@ -66,12 +66,8 @@ internal fun CacheKey.fieldKey(fieldName: String): String {
   return "${keyToString()}.$fieldName"
 }
 
-internal fun CacheKey.append(vararg keys: String): CacheKey {
-  var cacheKey: CacheKey = this
-  for (key in keys) {
-    cacheKey = CacheKey("${cacheKey.key}.$key")
-  }
-  return cacheKey
+internal fun CacheKey.append(key: String): CacheKey {
+  return CacheKey("${this.key}.$key")
 }
 
 internal fun Operation<*>.rootKey() = when (this) {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/Record.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/api/Record.kt
@@ -160,7 +160,14 @@ fun Collection<Record>?.dependentKeys(): Set<String> {
   if (this == null) {
     return emptySet()
   }
-  return buildSet {
+  // Counting the fields first is a cheap pass that lets the set be sized up front. A large operation
+  // has thousands of field keys, and growing to them from the default capacity rehashes the set a
+  // dozen times over.
+  var fieldCount = 0
+  for (record in this) {
+    fieldCount += record.fields.size
+  }
+  return buildSet(fieldCount) {
     for (record in this@dependentKeys) {
       for (fieldName in record.fields.keys) {
         add(record.key.fieldKey(fieldName))

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
@@ -12,10 +12,12 @@ import com.apollographql.cache.normalized.api.CacheHeaders
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.CacheResolver
 import com.apollographql.cache.normalized.api.DataWithErrors
+import com.apollographql.cache.normalized.api.FieldKeyContext
 import com.apollographql.cache.normalized.api.FieldKeyGenerator
 import com.apollographql.cache.normalized.api.ReadOnlyNormalizedCache
 import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.api.ResolverContext
+import com.apollographql.cache.normalized.api.fieldKey
 import com.apollographql.cache.normalized.api.isRootKey
 import com.apollographql.cache.normalized.cacheMissException
 import kotlin.jvm.JvmSuppressWildcards
@@ -102,6 +104,11 @@ internal class CacheBatchReader(
      * If true, cached server errors throw [ApolloGraphQLException], otherwise they are returned inside the [DataWithErrors].
      */
     private val serverErrorsAsException: Boolean,
+
+    /**
+     * If true, [CacheBatchReaderData.dependentKeys] holds the field keys that were read.
+     */
+    private val collectDependentKeys: Boolean = false,
 ) {
   /**
    * @param key: the key of the record we need to fetch
@@ -135,6 +142,30 @@ internal class CacheBatchReader(
   private var hasErrors = false
 
   private val pendingReferences = mutableListOf<PendingReference>()
+
+  /**
+   * The field keys read, or null if they were not asked for.
+   */
+  private val dependentKeys: MutableSet<String>? = if (collectDependentKeys) mutableSetOf() else null
+
+  /**
+   * Field keys, indexed by parent type name then by field. Computing one encodes the field's arguments
+   * to JSON, and the objects of a list are all read with the same fields.
+   *
+   * [CompiledField] has no `equals`, so the inner maps key on instance identity. Only populated when
+   * [dependentKeys] is, as the field keys the resolver computes are its own.
+   */
+  private val fieldKeys = mutableMapOf<String, MutableMap<CompiledField, String>>()
+
+  private fun memoizedFieldKey(parentType: String, field: CompiledField): String {
+    val keys = fieldKeys.getOrPut(parentType) { mutableMapOf() }
+    var fieldKey = keys[field]
+    if (fieldKey == null) {
+      fieldKey = fieldKeyGenerator.getFieldKey(FieldKeyContext(parentType, field, variables))
+      keys[field] = fieldKey
+    }
+    return fieldKey
+  }
 
   private class CollectState(val variables: Executable.Variables) {
     val fields = mutableListOf<CompiledField>()
@@ -249,6 +280,8 @@ internal class CacheBatchReader(
             return@mapNotNull null
           }
 
+          dependentKeys?.add(record.key.fieldKey(memoizedFieldKey(pendingReference.parentType, it)))
+
           val valuePath = pendingReference.path.append(it.responseName)
           val value = try {
             cacheResolver.resolveField(
@@ -312,6 +345,7 @@ internal class CacheBatchReader(
         rootPath = rootPath,
         cacheHeaders = CacheHeaders.Builder().apply { if (isStale) addHeader(ApolloCacheHeaders.STALE, "true") }.build(),
         hasErrors = hasErrors,
+        dependentKeys = dependentKeys,
     )
   }
 
@@ -401,6 +435,11 @@ internal class CacheBatchReader(
       private val rootPath: ResponsePath,
       val cacheHeaders: CacheHeaders,
       val hasErrors: Boolean,
+
+      /**
+       * The field keys the data was read from, or null if the read was not asked to collect them.
+       */
+      val dependentKeys: Set<String>? = null,
   ) {
     @Suppress("UNCHECKED_CAST")
     internal fun toMap(withErrors: Boolean = true): DataWithErrors {

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/CacheBatchReader.kt
@@ -156,7 +156,32 @@ internal class CacheBatchReader(
     }
   }
 
+  /**
+   * Collected fields, indexed by the selections they were collected from, then by the `__typename` of
+   * the object they were collected for.
+   *
+   * Collecting walks the whole selection set, and tests every fragment against its possible types.
+   * The objects of a list all share the same selections, so the result is reused rather than
+   * collected again for each of them.
+   *
+   * A selection set belongs to exactly one parent type, so `parentType` is not part of the key.
+   * Neither [CompiledField] nor [CompiledFragment] overrides `equals`, which makes the outer lookup a
+   * shallow, identity-based comparison of the selections: it never descends into fragments.
+   */
+  private val collectedFields = mutableMapOf<List<CompiledSelection>, MutableMap<String?, List<CompiledField>>>()
+
   private fun collectAndMergeSameDirectives(
+      selections: List<CompiledSelection>,
+      parentType: String,
+      variables: Executable.Variables,
+      typename: String?,
+  ): List<CompiledField> {
+    return collectedFields.getOrPut(selections) { mutableMapOf() }.getOrPut(typename) {
+      collectAndMergeSameDirectivesUncached(selections, parentType, variables, typename)
+    }
+  }
+
+  private fun collectAndMergeSameDirectivesUncached(
       selections: List<CompiledSelection>,
       parentType: String,
       variables: Executable.Variables,

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultCacheManager.kt
@@ -157,6 +157,7 @@ internal class DefaultCacheManager(
             fieldKeyGenerator = fieldKeyGenerator,
             cacheMissesAsException = cacheMissesAsException,
             serverErrorsAsException = serverErrorsAsException,
+            collectDependentKeys = cacheHeaders.headerValue(COLLECT_DEPENDENT_KEYS) == "true",
         ).collectData()
       } catch (e: ApolloException) {
         return ApolloResponse.Builder(operation, uuid4())
@@ -232,6 +233,9 @@ internal class DefaultCacheManager(
         .data(data)
         .errors(errors.takeIf { it.isNotEmpty() })
         .cacheHeaders(batchReaderData.cacheHeaders)
+        .apply {
+          batchReaderData.dependentKeys?.let { addExecutionContext(DependentKeysContext(it)) }
+        }
         .cacheInfo(
             CacheInfo.Builder()
                 .fromCache(true)

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DependentKeys.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DependentKeys.kt
@@ -1,0 +1,25 @@
+package com.apollographql.cache.normalized.internal
+
+import com.apollographql.apollo.api.ExecutionContext
+
+/**
+ * Cache header asking a read to report the field keys it read, as
+ * [CacheBatchReaderData.dependentKeys] and then as a [DependentKeysContext] on the response.
+ *
+ * Only watchers have a use for them, and collecting them costs a key per field read, so a read that
+ * did not ask for them does not pay for them.
+ */
+internal const val COLLECT_DEPENDENT_KEYS = "collect-dependent-keys"
+
+/**
+ * The field keys a response was read from.
+ *
+ * Only present on responses served by a cache read made with [COLLECT_DEPENDENT_KEYS], so a consumer
+ * needs a fallback for the responses of a network fetch.
+ */
+internal class DependentKeysContext(val dependentKeys: Set<String>) : ExecutionContext.Element {
+  override val key: ExecutionContext.Key<*>
+    get() = Key
+
+  companion object Key : ExecutionContext.Key<DependentKeysContext>
+}

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DependentKeys.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DependentKeys.kt
@@ -14,8 +14,7 @@ internal const val COLLECT_DEPENDENT_KEYS = "collect-dependent-keys"
 /**
  * The field keys a response was read from.
  *
- * Only present on responses served by a cache read made with [COLLECT_DEPENDENT_KEYS], so a consumer
- * needs a fallback for the responses of a network fetch.
+ * Only present on responses served by a cache read made with [COLLECT_DEPENDENT_KEYS] set to true.
  */
 internal class DependentKeysContext(val dependentKeys: Set<String>) : ExecutionContext.Element {
   override val key: ExecutionContext.Key<*>

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/Normalizer.kt
@@ -307,6 +307,21 @@ internal class Normalizer(
   }
 
   /**
+   * Collected fields, indexed by the selections they were collected from, then by the `__typename` of
+   * the object they were collected for.
+   *
+   * Collecting walks the whole selection set, and tests every fragment against its possible types.
+   * The objects of a list all share the same selections, so the result is reused rather than
+   * collected again for each of them.
+   *
+   * A selection set belongs to exactly one parent type, so `parentType` is not part of the key.
+   * Neither [CompiledField] nor [CompiledFragment] overrides `equals`, which makes the outer lookup a
+   * shallow, identity-based comparison of the selections: it never descends into fragments.
+   */
+  private val collectedFields =
+    mutableMapOf<List<CompiledSelection>, MutableMap<String?, Map<String, List<CompiledField>>>>()
+
+  /**
    * The fields selected on the object, indexed by response name.
    *
    * @param typename the typename of the object. It might be null if the `__typename` field wasn't queried. If
@@ -314,9 +329,11 @@ internal class Normalizer(
    * cache miss
    */
   private fun collectFields(selections: List<CompiledSelection>, parentType: String, typename: String?): Map<String, List<CompiledField>> {
-    val state = CollectState()
-    collectFields(selections, parentType, typename, state)
-    return state.fields
+    return collectedFields.getOrPut(selections) { mutableMapOf() }.getOrPut(typename) {
+      val state = CollectState()
+      collectFields(selections, parentType, typename, state)
+      state.fields
+    }
   }
 }
 

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
@@ -13,6 +13,7 @@ import com.apollographql.cache.normalized.CacheManager
 import com.apollographql.cache.normalized.DefaultFetchPolicyInterceptor
 import com.apollographql.cache.normalized.FetchPolicyContext
 import com.apollographql.cache.normalized.RefetchPolicyContext
+import com.apollographql.cache.normalized.addCacheHeader
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.dependentKeys
 import com.apollographql.cache.normalized.api.withErrors
@@ -44,15 +45,16 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
     /**
      * The data whose dependent keys are watched, and the keys themselves.
      *
-     * Computing the keys normalizes the whole data again, which is significant work for large
-     * operations. The keys are only ever read to filter an incoming cache change, so they are
-     * computed on the first such change rather than up front.
+     * A response served from the cache reports the keys it was read from, which are the keys to
+     * watch, so there is nothing left to compute for it. A response from the network does not, and
+     * neither does the data given to `watch(data)`: those are normalized again to get their keys.
      *
-     * This matters because of when the work would otherwise happen: the last of the initial
-     * responses is withheld below until this interceptor has subscribed to
+     * Normalizing is significant work for large operations, and the keys are only ever read to
+     * filter an incoming cache change, so it is deferred to the first such change rather than done
+     * up front. This matters because of when the work would otherwise happen: the last of the
+     * initial responses is withheld below until this interceptor has subscribed to
      * [CacheManager.changedKeys], so anything done before subscribing delays that response reaching
-     * the caller. The same applies to the responses of a refetch, which is why those only record the
-     * data and leave the keys stale.
+     * the caller.
      */
     var dataToWatch: Operation.Data? = watchContext.data
     var errorsToWatch: List<Error>? = null
@@ -84,6 +86,13 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
     }
 
     /**
+     * The request, asking the cache reads it triggers to report the field keys they read.
+     */
+    val watchedRequest = request.newBuilder()
+        .addCacheHeader(COLLECT_DEPENDENT_KEYS, "true")
+        .build()
+
+    /**
      * The request used when the cache changes.
      *
      * `watch()` fetches its initial responses with the fetch policy and refetches with the refetch
@@ -91,7 +100,7 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
      * no initial fetch and keeps the fetch policy throughout.
      */
     val refetchRequest = if (watchContext.fetchInitialResponses) {
-      request.newBuilder()
+      watchedRequest.newBuilder()
           .addExecutionContext(
               FetchPolicyContext(request.executionContext[RefetchPolicyContext]?.interceptor ?: DefaultFetchPolicyInterceptor),
           )
@@ -99,13 +108,21 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
           .onlyIfCached(request.refetchOnlyIfCached)
           .build()
     } else {
-      request
+      watchedRequest
     }
 
     fun proceedRecordingData(request: ApolloRequest<D>): Flow<ApolloResponse<D>> {
       return chain.proceed(request)
           .onEach { response ->
-            if (response.data != null) {
+            val readKeys = response.executionContext[DependentKeysContext]?.dependentKeys
+            if (readKeys != null) {
+              // Read from the cache, which reported the keys it read: nothing left to compute, and no
+              // need to hold on to the data.
+              watchedKeys = readKeys
+              watchedKeysAreStale = false
+              dataToWatch = null
+              errorsToWatch = null
+            } else if (response.data != null) {
               dataToWatch = response.data
               errorsToWatch = response.errors
               watchedKeysAreStale = true
@@ -137,7 +154,7 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
       var lastResponse: ApolloResponse<D>? = null
 
       if (watchContext.fetchInitialResponses) {
-        proceedRecordingData(request).collect { response ->
+        proceedRecordingData(watchedRequest).collect { response ->
           if (response.isLast) {
             /**
              * If we ever come here it means some interceptors built a new Flow and forgot to reset the isLast flag

--- a/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
@@ -92,6 +92,18 @@ class WatcherTest {
       )
   )
 
+  /**
+   * Changes the name of `Human:1000`, which [heroAndFriendsNamesWithIDsData] has as a friend, and
+   * touches nothing else it holds: the hero here is that same friend, and its own friend is an
+   * entity of its own.
+   */
+  private val heroAndFriendsNamesWithIDsFriendNameChangedData = HeroAndFriendsNamesWithIDsQuery.Data(
+      HeroAndFriendsNamesWithIDsQuery.Hero("Human", "1000", "Luke Starkiller", listOf(
+          HeroAndFriendsNamesWithIDsQuery.Friend("Human", "1004", "Wilhuff Tarkin"),
+      )
+      )
+  )
+
   private fun myRunTest(block: suspend CoroutineScope.() -> Unit) {
     kotlinx.coroutines.test.runTest(timeout = 10.minutes) {
       withContext(Dispatchers.Default.limitedParallelism(1)) {
@@ -373,6 +385,48 @@ class WatcherTest {
         .execute()
 
     assertEquals("ArTwo", channel.awaitElement()?.hero?.name)
+
+    job.cancel()
+  }
+
+  /**
+   * A refetch served from the cache reports the keys it read, and the watcher uses those from then on.
+   * They have to cover the whole response and not just its root: an object reached through a list is
+   * as much part of what the watcher depends on as the root field is.
+   */
+  @Test
+  fun watchedKeysFromACacheReadCoverListedObjects() = runTest(before = { setUp() }) {
+    val channel = Channel<HeroAndFriendsNamesWithIDsQuery.Data?>()
+
+    val heroAndFriendsNamesWithIDsQuery = HeroAndFriendsNamesWithIDsQuery(Episode.NEWHOPE)
+    apolloClient.enqueueTestResponse(heroAndFriendsNamesWithIDsQuery, heroAndFriendsNamesWithIDsData)
+    val job = launch {
+      apolloClient.query(heroAndFriendsNamesWithIDsQuery).watch().collect {
+        channel.send(it.data)
+      }
+    }
+
+    // Cache miss is emitted first (null data)
+    assertNull(channel.awaitElement())
+    assertEquals("Luke Skywalker", channel.awaitElement()?.hero?.friends?.get(0)?.name)
+
+    // Changing the hero triggers a refetch, which is served from the cache and so is where the
+    // watched keys come from afterwards
+    val episodeHeroNameWithIdQuery = EpisodeHeroNameWithIdQuery(Episode.EMPIRE)
+    apolloClient.enqueueTestResponse(episodeHeroNameWithIdQuery, episodeHeroNameWithIdChangedData)
+    apolloClient.query(episodeHeroNameWithIdQuery)
+        .fetchPolicy(FetchPolicy.NetworkOnly)
+        .execute()
+
+    assertEquals("ArTwo", channel.awaitElement()?.hero?.name)
+
+    // Changing one of the friends still reaches the watcher
+    apolloClient.enqueueTestResponse(HeroAndFriendsNamesWithIDsQuery(Episode.EMPIRE), heroAndFriendsNamesWithIDsFriendNameChangedData)
+    apolloClient.query(HeroAndFriendsNamesWithIDsQuery(Episode.EMPIRE))
+        .fetchPolicy(FetchPolicy.NetworkOnly)
+        .execute()
+
+    assertEquals("Luke Starkiller", channel.awaitElement()?.hero?.friends?.get(0)?.name)
 
     job.cancel()
   }


### PR DESCRIPTION
Remove the watcher's redundant normalize pass and trim the read path

## Description

A watcher filters incoming cache changes against the set of field keys its latest
response depends on. Deriving that set was, until now, a second full pass over the
response: serialize the data back to a map, normalize the whole tree into records,
then build a key string for every field of every record — all to produce a set whose
only use is one boolean intersection test.

The keys are already a by-product of the read that served the response. A watcher
refetches by reading the cache, and a read resolves each field from a record it has
in hand. This makes the read report what it read, and the watcher take it as-is.

Two smaller commits trim the per-field work on the read path itself, and stand on
their own if you'd prefer them separately.

### `perf(cache): Reuse the collected fields across objects of the same shape`

Field collection ran per object. The objects of a list are all read with the same
selections, so the result is now reused across them instead of recomputed for each.

### `perf(cache): Trim allocations while building field keys`

Field key construction allocated more than it needed to per field. Same keys, fewer
intermediate strings.

### `perf(cache): Take a watcher's dependent keys from the read that served it`

- `CacheBatchReader` collects `parentRecord.field` for each field it resolves, when
  asked to. Field keys are memoized per (parent type, field), so the objects of a
  list share the argument encoding — mirroring what `Normalizer` already does.
  Embedded objects are skipped: normalization folds them into their parent's field
  value, so they never become records of their own and contribute no keys.
- Collecting is opt-in through a cache header. A key per resolved field is not free,
  and only a watcher has any use for the result, so reads made by anything else are
  unchanged.
- The keys travel back on the response in an execution context element, which the
  watcher consumes — and then drops the response data it no longer has to retain.

A response from the network, and the data handed to `watch(data)`, carry no such
keys. Both keep normalizing to get them, still deferred to the first cache change
that actually needs them.

Errors resolved from the cache can make the collected set a superset of what
normalizing would produce. That is conservative in the safe direction — at worst an
extra refetch, which reads and writes nothing — and cannot feed back on itself.

### Why this is worth it

From a CPU profile of a large scrolling feed in a production app:

- Normalization ran about **ten times for every write that actually stored a record**.
  The other nine were watchers recomputing their key sets; a refetch served from the
  cache writes nothing.
- Recomputing watcher keys accounted for roughly **a third of all CPU spent in the
  cache**, split across normalization (~65%), re-serializing the response (~19%), and
  building the key strings (~16%).
- String operations and hash-container work dominated the leaf samples, which is what
  the two smaller commits target.

Caveats on the magnitudes: this was a debuggable build on an emulator with no AOT
compilation and no R8, from a single session. The ratios are the trustworthy part;
treat the absolute percentages as indicative. The two structural claims — that the
keys are recoverable from the read, and that ~90% of normalization passes write
nothing — come from reading the code, and hold independently of the profile.

### Compatibility

No public API change; `apiCheck` passes with no dump update. The cache header
constant and the execution context element are both `internal`. `readFragment`'s
reader is constructed without the flag, so it is untouched.

### Testing

- New `WatcherTest` case covering that keys taken from a cache read reach objects
  behind a list, not just the response root — verified non-vacuous by mutating the
  harvest to root-only, which fails it plus two pre-existing watcher tests.
- Full test suite green, including a forced re-run across the fetch-policy,
  normalization, partial-results, store-errors, optimistic-data, pagination,
  garbage-collection, and cache-control modules.

```
┌─────┬──────────────────────────────────────────────────────────────────┬──────────────┬───────────────────────────────────────────┐
│     │                               Fix                                │     Win      │                   Files                   │
├─────┼──────────────────────────────────────────────────────────────────┼──────────────┼───────────────────────────────────────────┤
│     │ Stop recomputing watcher dependent keys. Return touched field    │              │ WatcherInterceptor.kt:63-84,              │
│ P0  │ keys from readOperation (collectData already computes every one  │ 36.8% of     │ CacheBatchReader.kt:185,                  │
│     │ at lines 237/355); derive them from the Records the write path   │ Apollo CPU   │ DefaultCacheManager.kt:307/325            │
│     │ already holds. Deletes all three passes.                         │              │                                           │
├─────┼──────────────────────────────────────────────────────────────────┼──────────────┼───────────────────────────────────────────┤
│     │ Key representation: dependentKeys() builds a String per field    │ part of      │                                           │
│ P1  │ only to feed one anyIntersection — use hashes with exact         │ 27.9%        │ Record.kt:159, CacheKey.kt:65,            │
│     │ re-check on collision. Hoist the Normalizer field-key memo out   │ string+map   │ Normalizer.kt:69-78                       │
│     │ of per-instance scope so it survives across normalize calls.     │              │                                           │
├─────┼──────────────────────────────────────────────────────────────────┼──────────────┼───────────────────────────────────────────┤
│     │ Work around the List<String> scan without waiting on upstream:   │ ~3.3% of     │ Normalizer.kt:301,                        │
│ P1  │ memoize a Set<String> per CompiledFragment at the two call       │ Apollo       │ CacheBatchReader.kt:151                   │
│     │ sites.                                                           │              │                                           │
├─────┼──────────────────────────────────────────────────────────────────┼──────────────┼───────────────────────────────────────────┤
│ P2  │ Short-circuit the merged-field path — skip newBuilder() entirely │ small, cheap │ Normalizer.kt:142                         │
│     │  when includedFields.size == 1, which is the no-op case.         │              │                                           │
├─────┼──────────────────────────────────────────────────────────────────┼──────────────┼───────────────────────────────────────────┤
│ P2  │ Narrow watchedKeysAreStale re-arming so every pagination         │ reduces P0   │ WatcherInterceptor.kt:107-113             │
│     │ response doesn't re-arm a full recompute.                        │ frequency    │                                           │
└─────┴──────────────────────────────────────────────────────────────────┴──────────────┴───────────────────────────────────────────┘
```