### PR TITLE
fix(cache): Don't refetch a watcher for the asynchronous write of its own initial fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [Improvement] Reduce allocations and copies in the SQLite cache: stream records straight out of the query buffer, and slice large records instead of boxing them byte by byte (#383)
 - [Improvement] Don't build the max age field path when the `MaxAgeProvider` is a `GlobalMaxAgeProvider`, which ignores it (#383)
 - [Fix] Cache headers set on the client are no longer discarded by a call that sets cache headers of its own. Whether the two were merged used to depend on the order the options were set in (#379)
-- [Fix] `watch` no longer emits a second time for the cache write of its own initial fetch when using `writeToCacheAsynchronously`. That write lands after its response has been emitted and after the watcher has subscribed to the cache, so the watcher used to be notified of a change it had just made itself and refetched to emit data the caller already had. Cache changes made anywhere else still notify it
+- [Behavior change] `watch` no longer emits a second time for the cache write of its own initial fetch when using `writeToCacheAsynchronously`. That write lands after its response has been emitted and after the watcher has subscribed to the cache, so the watcher used to be notified of a change it had just made itself and refetched to emit data the caller already had. Cache changes made anywhere else still notify it (#387)
 - [Fix] SQL cache: a cascading `remove` reaching more keys than SQLite accepts parameters for reported deleting nothing (#384)
 
 PUT_CHANGELOG_HERE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Improvement] Reduce allocations and copies in the SQLite cache: stream records straight out of the query buffer, and slice large records instead of boxing them byte by byte (#383)
 - [Improvement] Don't build the max age field path when the `MaxAgeProvider` is a `GlobalMaxAgeProvider`, which ignores it (#383)
 - [Fix] Cache headers set on the client are no longer discarded by a call that sets cache headers of its own. Whether the two were merged used to depend on the order the options were set in (#379)
+- [Fix] `watch` no longer emits a second time for the cache write of its own initial fetch when using `writeToCacheAsynchronously`. That write lands after its response has been emitted and after the watcher has subscribed to the cache, so the watcher used to be notified of a change it had just made itself and refetched to emit data the caller already had. Cache changes made anywhere else still notify it
 - [Fix] SQL cache: a cascading `remove` reaching more keys than SQLite accepts parameters for reported deleting nothing (#384)
 
 PUT_CHANGELOG_HERE

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -76,7 +76,11 @@ internal class ApolloCacheInterceptor(
       } else {
         emptySet()
       }
-      cacheManager.publish(cacheKeys + extraKeys)
+      val publishedKeys = cacheKeys + extraKeys
+      // Recorded before publishing, so that a watcher collecting the event can already tell that it
+      // comes from a write of its own.
+      request.executionContext[PublishedKeysContext]?.record(publishedKeys)
+      cacheManager.publish(publishedKeys)
     }
   }
 

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/PublishedKeys.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/PublishedKeys.kt
@@ -1,0 +1,46 @@
+package com.apollographql.cache.normalized.internal
+
+import com.apollographql.apollo.api.ExecutionContext
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+
+/**
+ * Collects the key sets that the cache writes of a request publish, so that the caller can tell a
+ * cache change it caused itself apart from anyone else's.
+ *
+ * Only a watcher has a use for this, and only when its writes are asynchronous: a synchronous write
+ * publishes before its response is emitted, which is before the watcher subscribes to
+ * [com.apollographql.cache.normalized.CacheManager.changedKeys], so there is no event to tell apart.
+ *
+ * Sets are matched by identity: each publication is its own event, even if two of them carry equal
+ * keys.
+ */
+internal class PublishedKeysContext : ExecutionContext.Element {
+  private val published = atomic<List<Set<String>>>(emptyList())
+
+  /**
+   * Records [keys] as about to be published. Must be called before publishing them, so that whoever
+   * collects the event can already see them here.
+   */
+  fun record(keys: Set<String>) {
+    published.update { it + listOf(keys) }
+  }
+
+  /**
+   * Whether [keys] is one of the recorded sets, which is then forgotten.
+   */
+  fun consume(keys: Set<*>): Boolean {
+    var consumed = false
+    published.update { recorded ->
+      val index = recorded.indexOfFirst { it === keys }
+      consumed = index != -1
+      if (consumed) recorded.filterIndexed { i, _ -> i != index } else recorded
+    }
+    return consumed
+  }
+
+  override val key: ExecutionContext.Key<*>
+    get() = Key
+
+  companion object Key : ExecutionContext.Key<PublishedKeysContext>
+}

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
@@ -22,6 +22,7 @@ import com.apollographql.cache.normalized.options.onlyIfCached
 import com.apollographql.cache.normalized.options.refetchNoCache
 import com.apollographql.cache.normalized.options.refetchOnlyIfCached
 import com.apollographql.cache.normalized.watchContext
+import com.apollographql.cache.normalized.writeToCacheAsynchronously
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.emitAll
@@ -93,11 +94,42 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
         .build()
 
     /**
+     * The keys published by the cache writes of the initial fetch, when those writes are
+     * asynchronous.
+     *
+     * Such a write lands after its response has been emitted and after the subscription below is
+     * established, so the watcher is notified of a change it has itself just made and would refetch
+     * to emit data it has already emitted. Its own notifications are recognized here and dropped.
+     *
+     * A synchronous write publishes before its response is emitted, which is before the subscription
+     * exists, so there is nothing to recognize and nothing to record.
+     */
+    val ownPublishedKeys = if (watchContext.fetchInitialResponses && request.writeToCacheAsynchronously) {
+      PublishedKeysContext()
+    } else {
+      null
+    }
+
+    /**
+     * The request used for the initial fetch.
+     */
+    val initialRequest = if (ownPublishedKeys == null) {
+      watchedRequest
+    } else {
+      watchedRequest.newBuilder()
+          .addExecutionContext(ownPublishedKeys)
+          .build()
+    }
+
+    /**
      * The request used when the cache changes.
      *
      * `watch()` fetches its initial responses with the fetch policy and refetches with the refetch
      * policy, so the latter has to be applied here rather than to the whole call. `watch(data)` has
      * no initial fetch and keeps the fetch policy throughout.
+     *
+     * A refetch does not report what it publishes: it runs while subscribed either way, so being
+     * notified of its own write is not specific to writing asynchronously and is left as is.
      */
     val refetchRequest = if (watchContext.fetchInitialResponses) {
       watchedRequest.newBuilder()
@@ -131,6 +163,10 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
     }
 
     fun isWatched(changedKeys: Set<*>): Boolean {
+      if (ownPublishedKeys?.consume(changedKeys) == true) {
+        // The initial fetch's own asynchronous write: its data has already been emitted.
+        return false
+      }
       if (changedKeys === CacheManager.ALL_KEYS) {
         // Matches regardless of the watched keys, so there is no need to compute them.
         return true
@@ -154,7 +190,7 @@ internal class WatcherInterceptor(val cacheManager: CacheManager) : ApolloInterc
       var lastResponse: ApolloResponse<D>? = null
 
       if (watchContext.fetchInitialResponses) {
-        proceedRecordingData(watchedRequest).collect { response ->
+        proceedRecordingData(initialRequest).collect { response ->
           if (response.isLast) {
             /**
              * If we ever come here it means some interceptors built a new Flow and forgot to reset the isLast flag

--- a/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/watch.kt
+++ b/normalized-cache/src/commonMain/kotlin/com/apollographql/cache/normalized/options/watch.kt
@@ -42,7 +42,8 @@ internal val <D : Operation.Data> ApolloRequest<D>.watchContext: WatchContext?
  * The cache subscription is established before the last initial response is collected, so any external cache update made
  * after collecting it will be received.
  *
- * Note: when using [writeToCacheAsynchronously], the cache updates are postponed and behave as external cache updates. They may trigger emission. 
+ * Note: when using [writeToCacheAsynchronously], the cache updates are postponed until after the response they come from has been emitted.
+ * They do not trigger an emission of their own: the data they store has already been emitted. Cache updates made anywhere else still do.
  *
  * [fetchPolicy] controls how the result is first queried (default: [FetchPolicy.CacheFirst]), while [refetchPolicy] will control the subsequent fetches (default: [FetchPolicy.CacheOnly]).
  *

--- a/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/fetch-policy/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -7,7 +7,6 @@ import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Operation
-import com.apollographql.apollo.exception.ApolloGraphQLException
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
@@ -45,7 +44,6 @@ import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -107,17 +105,83 @@ class FetchPolicyTest {
                       networkResponse1.errors
                   )
 
-                  // 3. with writeToCacheAsynchronously, when the network response is written to the cache, the watcher gets notified with the cache response
-                  val cacheResponse2 = awaitItem()
-                  assertTrue(cacheResponse2.isFromCache)
-                  // GraphQL error is surfaced as an exception by default (serverErrorsAsException is true)
-                  assertIs<ApolloGraphQLException>(cacheResponse2.exception)
-                  assertNull(cacheResponse2.cacheInfo?.cacheMissException)
-
-                  // That wasn't a cache miss: expect no more emissions
-                  withTurbineTimeout(200.milliseconds) {
+                  // With writeToCacheAsynchronously, the network response is written to the cache after being
+                  // emitted, and the watcher is not notified of that write of its own: the data it stored has
+                  // already been emitted.
+                  withTurbineTimeout(500.milliseconds) {
                     assertFails { awaitItem() }
                   }
+
+                  cancelAndIgnoreRemainingEvents()
+                }
+          }
+    }
+  }
+
+  @Test
+  fun writeToCacheAsyncWatcherIsNotifiedOfOtherWritesOnly() = runTest {
+    MockServer().use { mockServer ->
+      mockServer.enqueueString(
+          // language=JSON
+          """
+          {
+            "data": {
+              "me": {
+                "__typename": "User",
+                "id": "1",
+                "firstName": "John",
+                "lastName": "Smith"
+              }
+            }
+          }
+          """.trimIndent()
+      )
+      mockServer.enqueueString(
+          // language=JSON
+          """
+          {
+            "data": {
+              "me": {
+                "__typename": "User",
+                "id": "1",
+                "firstName": "Jane",
+                "lastName": "Doe"
+              }
+            }
+          }
+          """.trimIndent()
+      )
+      ApolloClient.Builder()
+          .serverUrl(mockServer.url())
+          .cache(AsyncCacheFactory(), writeToCacheAsynchronously = true)
+          .build()
+          .use { apolloClient ->
+            apolloClient.query(MeQuery())
+                .watch()
+                .test {
+                  // 1. response from the cache (cache miss)
+                  val cacheResponse = awaitItem()
+                  assertTrue(cacheResponse.isFromCache)
+                  assertIs<CacheMissException>(cacheResponse.exception)
+
+                  // 2. response from the network
+                  val networkResponse = awaitItem()
+                  assertFalse(networkResponse.isFromCache)
+                  assertEquals("John", networkResponse.data?.me?.firstName)
+
+                  // The initial fetch writes to the cache after emitting, and after this watcher has
+                  // subscribed to it. That write is the watcher's own: it does not emit for it.
+                  withTurbineTimeout(500.milliseconds) {
+                    assertFails { awaitItem() }
+                  }
+
+                  // A write made by anyone else still notifies it.
+                  apolloClient.query(MeQuery())
+                      .fetchPolicy(FetchPolicy.NetworkOnly)
+                      .execute()
+                  val cacheResponse2 = awaitItem()
+                  assertTrue(cacheResponse2.isFromCache)
+                  assertEquals("Jane", cacheResponse2.data?.me?.firstName)
 
                   cancelAndIgnoreRemainingEvents()
                 }


### PR DESCRIPTION
With `writeToCacheAsynchronously`, the cache write of a response is launched rather than awaited, so it lands after the response has been emitted - and, for the initial fetch of a `watch()`, after the watcher has subscribed to the cache. The watcher was then notified of a change it had just made itself, and refetched to emit data the caller already had.

A synchronous write cannot do that: it publishes before its response is emitted, which is before the watcher subscribes, which is the whole reason the last initial response is withheld until the subscription exists.

The cache write now reports the exact set of keys it is about to publish to the request that asked for it, and the watcher drops the event carrying that set. Sets are matched by identity, so each publication is its own event and a change published by anyone else - including one that touches the same keys - still notifies the watcher. Nothing is lost by dropping it: the response the write stored has already been emitted, and any other write that merged into the same records publishes an event of its own.

Only the initial fetch reports what it publishes. A refetch runs while subscribed whether writes are asynchronous or not, so being notified of its own write is not specific to this flag and is left as is.

Fixes: https://github.com/apollographql/apollo-kotlin-normalized-cache/issues/375